### PR TITLE
(Fix) loader not loading after deployment has finished

### DIFF
--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -23,7 +23,6 @@ import { toast } from '../../utils/utils'
 import { StepNavigation } from '../Common/StepNavigation'
 import { DisplayField } from '../Common/DisplayField'
 import { DisplayTextArea } from '../Common/DisplayTextArea'
-import { Loader } from '../Common/Loader'
 import { TxProgressStatus } from '../Common/TxProgressStatus'
 import { ModalContainer } from '../Common/ModalContainer'
 import { copy } from '../../utils/copy'
@@ -42,7 +41,6 @@ export class stepFour extends React.Component {
     super(props)
     this.state = {
       contractDownloaded: false,
-      loading: false,
       showModal: false
     }
   }
@@ -82,7 +80,6 @@ export class stepFour extends React.Component {
 
     executeSequentially(deploymentSteps)
       .then(() => this.hideModal())
-      .then(() => this.hideLoader())
       .then(() => successfulDeployment())
       .catch(this.handleError)
   }
@@ -96,16 +93,11 @@ export class stepFour extends React.Component {
       deploymentStore.setDeploymentStep(deploymentStepsOffset + failedAt)
 
     } else {
-      this.hideLoader()
       this.hideModal()
       toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.TRANSACTION_FAILED })
     }
 
     console.error([failedAt, err])
-  }
-
-  hideLoader() {
-    this.setState({ loading: false })
   }
 
   hideModal() {
@@ -114,7 +106,6 @@ export class stepFour extends React.Component {
 
   userHideModal = () => {
     this.hideModal()
-    if (!this.props.deploymentStore.deploymentHasFinished) this.setState({ loading: true })
   }
 
   handleContentByParent(content, index = 0) {
@@ -466,7 +457,6 @@ export class stepFour extends React.Component {
         >
           <TxProgressStatus txMap={deploymentStore.txMap} deployCrowdsale={this.deployCrowdsale} />
         </ModalContainer>
-        <Loader show={this.state.loading}/>
         <PreventRefresh/>
       </section>
     )}

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -82,6 +82,7 @@ export class stepFour extends React.Component {
 
     executeSequentially(deploymentSteps)
       .then(() => this.hideModal())
+      .then(() => this.hideLoader())
       .then(() => successfulDeployment())
       .catch(this.handleError)
   }

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -41,7 +41,7 @@ export class stepFour extends React.Component {
     super(props)
     this.state = {
       contractDownloaded: false,
-      showModal: false
+      modal: false
     }
   }
 
@@ -53,7 +53,7 @@ export class stepFour extends React.Component {
   componentDidMount () {
     scrollToBottom()
     copy('copy')
-    this.setState({ showModal: true })
+    this.showModal()
 
     if (process.env.NODE_ENV !== 'development') this.deployCrowdsale()
   }
@@ -100,8 +100,12 @@ export class stepFour extends React.Component {
     console.error([failedAt, err])
   }
 
-  hideModal() {
-    this.setState({ showModal: false })
+  hideModal = () => {
+    this.setState({ modal: false })
+  }
+
+  showModal = () => {
+    this.setState({ modal: true })
   }
 
   handleContentByParent(content, index = 0) {
@@ -448,7 +452,7 @@ export class stepFour extends React.Component {
         </div>
         <ModalContainer
           title={'Tx Status'}
-          showModal={this.state.showModal}
+          showModal={this.state.modal}
         >
           <TxProgressStatus txMap={deploymentStore.txMap} deployCrowdsale={this.deployCrowdsale} />
         </ModalContainer>

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -104,10 +104,6 @@ export class stepFour extends React.Component {
     this.setState({ showModal: false })
   }
 
-  userHideModal = () => {
-    this.hideModal()
-  }
-
   handleContentByParent(content, index = 0) {
     const { parent } = content
 
@@ -452,7 +448,6 @@ export class stepFour extends React.Component {
         </div>
         <ModalContainer
           title={'Tx Status'}
-          hideModal={this.userHideModal}
           showModal={this.state.showModal}
         >
           <TxProgressStatus txMap={deploymentStore.txMap} deployCrowdsale={this.deployCrowdsale} />


### PR DESCRIPTION
Closes #566 

Seems that the user closed the deployment steps modal, and the process was lacking of the option to close the _loading_ overlay.
