### PR TITLE
(Feature) Clear localStorage at start if there is no deploy in progress

### DIFF
--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -61,7 +61,7 @@ export class stepFour extends React.Component {
   deployCrowdsale = () => {
     const { contractStore, deploymentStore } = this.props
     const isWhitelistWithCap = contractStore.contractType === CONTRACT_TYPES.whitelistwithcap
-    const firstRun = deploymentStore.deploymentStep === undefined
+    const firstRun = deploymentStore.deploymentStep === null
 
     if (isWhitelistWithCap) {
       if (firstRun) {
@@ -200,7 +200,7 @@ export class stepFour extends React.Component {
 
     const newHistory = isValidContract ? url : crowdsalePage
 
-    localStorage.clear()
+    this.props.deploymentStore.resetDeploymentStep()
 
     this.props.history.push(newHistory)
   }

--- a/src/stores/ContractStore.js
+++ b/src/stores/ContractStore.js
@@ -36,7 +36,4 @@ class ContractStore {
   }
 }
 
-const contractStore = new ContractStore();
-
-export default contractStore;
-export { ContractStore };
+export default ContractStore;

--- a/src/stores/CrowdsaleBlockListStore.js
+++ b/src/stores/CrowdsaleBlockListStore.js
@@ -30,7 +30,4 @@ class CrowdsaleBlockListStore {
   }
 }
 
-const crowdsaleBlockListStore = new CrowdsaleBlockListStore();
-
-export default crowdsaleBlockListStore;
-export { CrowdsaleBlockListStore };
+export default CrowdsaleBlockListStore;

--- a/src/stores/CrowdsalePageStore.js
+++ b/src/stores/CrowdsalePageStore.js
@@ -18,7 +18,4 @@ class CrowdsalePageStore {
   }
 }
 
-const crowdsalePageStore = new CrowdsalePageStore();
-
-export default crowdsalePageStore;
-export { CrowdsalePageStore };
+export default CrowdsalePageStore;

--- a/src/stores/CrowdsaleStore.js
+++ b/src/stores/CrowdsaleStore.js
@@ -41,7 +41,4 @@ class CrowdsaleStore {
   }
 }
 
-const crowdsaleStore = new CrowdsaleStore()
-
-export default crowdsaleStore
-export { CrowdsaleStore }
+export default CrowdsaleStore

--- a/src/stores/DeploymentStore.js
+++ b/src/stores/DeploymentStore.js
@@ -102,7 +102,4 @@ class DeploymentStore {
   }
 }
 
-const deploymentStore = new DeploymentStore()
-
-export default deploymentStore
-export { DeploymentStore }
+export default DeploymentStore

--- a/src/stores/DeploymentStore.js
+++ b/src/stores/DeploymentStore.js
@@ -3,7 +3,7 @@ import autosave from './autosave'
 
 class DeploymentStore {
   @observable txMap = new Map()
-  @observable deploymentStep
+  @observable deploymentStep = null
 
   constructor() {
     autosave(this, 'DeploymentStore', (store) => {
@@ -69,6 +69,10 @@ class DeploymentStore {
 
   @action setDeploymentStep = (index) => {
     this.deploymentStep = index
+  }
+
+  @action resetDeploymentStep = () => {
+    this.deploymentStep = null
   }
 
   logTxMap = () => {

--- a/src/stores/GasPriceStore.js
+++ b/src/stores/GasPriceStore.js
@@ -91,7 +91,4 @@ class GasPriceStore {
   }
 }
 
-const gasPriceStore = new GasPriceStore()
-
-export default gasPriceStore
-export { GasPriceStore }
+export default GasPriceStore

--- a/src/stores/GeneralStore.js
+++ b/src/stores/GeneralStore.js
@@ -20,7 +20,4 @@ class GeneralStore {
   }
 }
 
-const generalStore = new GeneralStore();
-
-export default generalStore;
-export { GeneralStore };
+export default GeneralStore;

--- a/src/stores/InvestStore.js
+++ b/src/stores/InvestStore.js
@@ -9,7 +9,4 @@ class InvestStore {
   }
 }
 
-const investStore = new InvestStore();
-
-export default investStore;
-export { InvestStore };
+export default InvestStore;

--- a/src/stores/PricingStrategyStore.js
+++ b/src/stores/PricingStrategyStore.js
@@ -26,7 +26,4 @@ class PricingStrategyStore {
   }
 }
 
-const pricingStrategyStore = new PricingStrategyStore();
-
-export default pricingStrategyStore;
-export { PricingStrategyStore };
+export default PricingStrategyStore;

--- a/src/stores/ReservedTokenStore.js
+++ b/src/stores/ReservedTokenStore.js
@@ -43,7 +43,4 @@ class ReservedTokenStore {
   }
 }
 
-const reservedTokenStore = new ReservedTokenStore();
-
-export default reservedTokenStore;
-export { ReservedTokenStore };
+export default ReservedTokenStore;

--- a/src/stores/StepThreeValidationStore.js
+++ b/src/stores/StepThreeValidationStore.js
@@ -27,7 +27,4 @@ class StepThreeValidationStore {
   }
 }
 
-const stepThreeValidationStore = new StepThreeValidationStore();
-
-export default stepThreeValidationStore;
-export { StepThreeValidationStore };
+export default StepThreeValidationStore;

--- a/src/stores/StepTwoValidationStore.js
+++ b/src/stores/StepTwoValidationStore.js
@@ -20,7 +20,4 @@ class StepTwoValidationStore {
   }
 }
 
-const stepTwoValidationStore = new StepTwoValidationStore();
-
-export default stepTwoValidationStore;
-export { StepTwoValidationStore };
+export default StepTwoValidationStore;

--- a/src/stores/TierCrowdsaleListStore.js
+++ b/src/stores/TierCrowdsaleListStore.js
@@ -26,7 +26,4 @@ class TierCrowdsaleListStore {
   }
 }
 
-const tierCrowdsaleListStore = new TierCrowdsaleListStore();
-
-export default tierCrowdsaleListStore;
-export { TierCrowdsaleListStore };
+export default TierCrowdsaleListStore;

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -173,7 +173,4 @@ class TierStore {
   }
 }
 
-const tierStore = new TierStore();
-
-export default tierStore;
-export { TierStore };
+export default TierStore;

--- a/src/stores/TokenStore.js
+++ b/src/stores/TokenStore.js
@@ -76,7 +76,4 @@ class TokenStore {
   }
 }
 
-const tokenStore = new TokenStore();
-
-export default tokenStore;
-export { TokenStore };
+export default TokenStore;

--- a/src/stores/Web3Store.js
+++ b/src/stores/Web3Store.js
@@ -41,7 +41,4 @@ class Web3Store {
   }
 }
 
-const web3Store = new Web3Store();
-
-export default web3Store;
-export { Web3Store };
+export default Web3Store;

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,35 +1,53 @@
-import contractStore from './ContractStore';
-import pricingStrategyStore from './PricingStrategyStore';
-import reservedTokenStore from './ReservedTokenStore';
-import stepThreeValidationStore from './StepThreeValidationStore';
-import stepTwoValidationStore from './StepTwoValidationStore';
-import tierStore from './TierStore';
-import tokenStore from './TokenStore';
-import web3Store from './Web3Store';
-import tierCrowdsaleListStore from './TierCrowdsaleListStore'
-import crowdsaleBlockListStore from './CrowdsaleBlockListStore'
-import generalStore from './GeneralStore'
-import crowdsalePageStore from './CrowdsalePageStore'
-import investStore from './InvestStore'
-import crowdsaleStore from './CrowdsaleStore'
-import gasPriceStore from './GasPriceStore'
-import deploymentStore from './DeploymentStore'
+import storage from 'store2'
+import ContractStore from './ContractStore';
+import PricingStrategyStore from './PricingStrategyStore';
+import ReservedTokenStore from './ReservedTokenStore';
+import StepThreeValidationStore from './StepThreeValidationStore';
+import StepTwoValidationStore from './StepTwoValidationStore';
+import TierStore from './TierStore';
+import TokenStore from './TokenStore';
+import Web3Store from './Web3Store';
+import TierCrowdsaleListStore from './TierCrowdsaleListStore'
+import CrowdsaleBlockListStore from './CrowdsaleBlockListStore'
+import GeneralStore from './GeneralStore'
+import CrowdsalePageStore from './CrowdsalePageStore'
+import InvestStore from './InvestStore'
+import CrowdsaleStore from './CrowdsaleStore'
+import GasPriceStore from './GasPriceStore'
+import DeploymentStore from './DeploymentStore'
+
+const generalStore = new GeneralStore()
+const crowdsalePageStore = new CrowdsalePageStore()
+const tierCrowdsaleListStore = new TierCrowdsaleListStore()
+const crowdsaleBlockListStore = new CrowdsaleBlockListStore()
+const contractStore = new ContractStore()
+const pricingStrategyStore = new PricingStrategyStore()
+const reservedTokenStore = new ReservedTokenStore()
+const stepThreeValidationStore = new StepThreeValidationStore()
+const stepTwoValidationStore = new StepTwoValidationStore()
+const tierStore = new TierStore()
+const tokenStore = new TokenStore()
+const web3Store = new Web3Store()
+const investStore = new InvestStore()
+const crowdsaleStore = new CrowdsaleStore()
+const gasPriceStore = new GasPriceStore()
+const deploymentStore = new DeploymentStore()
 
 export {
-    generalStore,
-    crowdsalePageStore,
-    tierCrowdsaleListStore,
-    crowdsaleBlockListStore,
-    contractStore,
-    pricingStrategyStore,
-    reservedTokenStore,
-    stepThreeValidationStore,
-    stepTwoValidationStore,
-    tierStore,
-    tokenStore,
-    web3Store,
-    investStore,
-    crowdsaleStore,
-    gasPriceStore,
-    deploymentStore
+  generalStore,
+  crowdsalePageStore,
+  tierCrowdsaleListStore,
+  crowdsaleBlockListStore,
+  contractStore,
+  pricingStrategyStore,
+  reservedTokenStore,
+  stepThreeValidationStore,
+  stepTwoValidationStore,
+  tierStore,
+  tokenStore,
+  web3Store,
+  investStore,
+  crowdsaleStore,
+  gasPriceStore,
+  deploymentStore
 };

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -16,6 +16,11 @@ import CrowdsaleStore from './CrowdsaleStore'
 import GasPriceStore from './GasPriceStore'
 import DeploymentStore from './DeploymentStore'
 
+// Clear local storage if there is no incomplete deployment
+if (storage.has('DeploymentStore') && storage.get('DeploymentStore').deploymentStep === null) {
+  localStorage.clear()
+}
+
 const generalStore = new GeneralStore()
 const crowdsalePageStore = new CrowdsalePageStore()
 const tierCrowdsaleListStore = new TierCrowdsaleListStore()

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -108,13 +108,13 @@ export const getconstructorParams = (abiConstructor, vals, crowdsaleNum, isCrowd
         case "_crowdsale":
           params.vals.push(contractStore.crowdsale.addr[crowdsaleNum]);
           break;
-        case "_name": {
+        case "_name":
           if (isCrowdsale) {
             params.vals.push(tierStore.tiers[crowdsaleNum].tier);
           } else {
             params.vals.push(tokenStore.name);
           }
-        } break;
+          break;
         case "_symbol":
           params.vals.push(tokenStore.ticker);
           break;


### PR DESCRIPTION
This is the second step towards #529.

This simply checks if the `deploymentStep` in local storage is null. If that's the case, the local storage is cleared. If not, then it means a deployment is in progress, so the storage is left untouched. It also sets the `deploymentStep` to null when the deploy is finished.

Most of the other changes consist of moving the creation of the stores to `stores/index.js`: this is necessary to be able to execute some code before the stores are created.