### PR TITLE
(Feature) Save deploymentStep in each step

### DIFF
--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -76,9 +76,11 @@ export class stepFour extends React.Component {
   resumeContractDeployment = () => {
     const { deploymentStore } = this.props
     const startAt = deploymentStore.deploymentStep ? deploymentStore.deploymentStep : 0
-    const deploymentSteps = buildDeploymentSteps().slice(startAt)
+    const deploymentSteps = buildDeploymentSteps()
 
-    executeSequentially(deploymentSteps)
+    executeSequentially(deploymentSteps, startAt, (index) => {
+      deploymentStore.setDeploymentStep(index)
+    })
       .then(() => this.hideModal())
       .then(() => successfulDeployment())
       .catch(this.handleError)
@@ -89,8 +91,7 @@ export class stepFour extends React.Component {
 
     if (!deploymentStore.deploymentHasFinished) {
       toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.TRANSACTION_FAILED, options: {time: 1000} })
-      const deploymentStepsOffset = deploymentStore.deploymentStep || 0
-      deploymentStore.setDeploymentStep(deploymentStepsOffset + failedAt)
+      deploymentStore.setDeploymentStep(failedAt)
 
     } else {
       this.hideModal()

--- a/src/utils/executeSequentially.js
+++ b/src/utils/executeSequentially.js
@@ -3,12 +3,15 @@
  * @param {Array} list - List of promises to be executed
  * @returns {Promise} - If fails, returns the err with the index of the function in the list
  */
-const executeSequentially = (list) => {
-  return list.reduce((promise, fn, index) => {
+const executeSequentially = (list, startAt = 0, cb = () => {}) => {
+  return list.slice(startAt).reduce((promise, fn, index) => {
     return promise.then(() => {
       return Promise.resolve()
-        .then(() => fn())
-        .catch((err) => Promise.reject([err, index]))
+        .then(() => {
+          cb(startAt + index)
+          return fn()
+        })
+        .catch((err) => Promise.reject([err, startAt + index]))
     })
   }, Promise.resolve())
 


### PR DESCRIPTION
Part of #529.

This fixes an issue that @fernandomg found: the deploy was resumable if a transaction had failed and you refreshed the browser, but if the browser was closed during or after a successful transaction, then the deploy would resume from the beginning (or the last failed step).