### PR TITLE
(Feature) Improve deployment resume

### DIFF
--- a/src/components/IncompleteDeploy.js
+++ b/src/components/IncompleteDeploy.js
@@ -1,10 +1,16 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom'
+import { cancellingIncompleteDeploy } from '../utils/alerts'
 
 class CheckIncompleteDeploy extends Component {
   cancel() {
-    localStorage.clear()
-    window.location.reload()
+    return cancellingIncompleteDeploy()
+      .then(result => {
+        if (result.value) {
+          localStorage.clear()
+          window.location.reload()
+        }
+      })
   }
 
   render() {

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -53,7 +53,9 @@ export class stepFour extends React.Component {
   componentDidMount () {
     scrollToBottom()
     copy('copy')
-    this.showModal()
+    if (!this.props.deploymentStore.deploymentHasFinished) {
+      this.showModal()
+    }
 
     if (process.env.NODE_ENV !== 'development') this.deployCrowdsale()
   }

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -103,8 +103,8 @@ export function warningOnMainnetAlert(tiersCount, priceSelected, reservedCount, 
   sweetAlert2({
     title: "Warning",
     html: `You are about to sign ${estimatedTxsCount} TXs. You will see an individual Metamask windows for each of it.
-     Please don't open two or more instances of Wizard in one browser. Token Wizard will create ${tiersCount}-tier(s) 
-     crowdsale for you. The total cost will be around ${estimatedCost.toFixed(2)} ETH. Are you sure you want to 
+     Please don't open two or more instances of Wizard in one browser. Token Wizard will create ${tiersCount}-tier(s)
+     crowdsale for you. The total cost will be around ${estimatedCost.toFixed(2)} ETH. Are you sure you want to
      proceed?`,
     type: "warning",
     showCancelButton: true,
@@ -179,4 +179,16 @@ export function mainnetIsOnMaintenance() {
     html: "Token Wizard on Mainnet is down for maintenance. For updates, please check <a href='https://gitter.im/poanetwork/token-wizard'>our gitter</a>",
     type: "warning"
   });
+}
+
+export function cancellingIncompleteDeploy() {
+  return sweetAlert2({
+    title: "Cancel crowdsale deploy",
+    html: "Are you sure you want to cancel the deployment of the crowdsale? This action cannot be undone.",
+    type: "warning",
+    showCancelButton: true,
+    cancelButtonText: "No",
+    confirmButtonText: "Yes",
+    reverseButtons: true
+  })
 }


### PR DESCRIPTION
Part of #529.

Two additions to the resume deployment feature:

- Show a warning when the user cancels a deployment in progress (please check the warning message and tell me if it's OK).
- Don't show the progress modal if the deployment has already finished (this fixes an issue that appears when you refresh the page in step four after the deploy finished: the modal was shown but there was no way to close it).