### PR TITLE
(Feature) Show skip button if transaction fails.

### DIFF
--- a/src/components/Common/TxProgressStatus.js
+++ b/src/components/Common/TxProgressStatus.js
@@ -65,6 +65,10 @@ export class TxProgressStatus extends Component {
                 : <a onClick={this.props.deployCrowdsale} className="no_image button button_fill">Resume deploy...</a>
               : null
             }
+            {this.props.onSkip
+              ? <a onClick={this.props.onSkip} className="no_image button button_fill">Skip transaction</a>
+              : null
+            }
           </div>
         </div>
         : null

--- a/src/components/IncompleteDeploy.js
+++ b/src/components/IncompleteDeploy.js
@@ -1,10 +1,16 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom'
+import { cancellingIncompleteDeploy } from '../utils/alerts'
 
 class CheckIncompleteDeploy extends Component {
   cancel() {
-    localStorage.clear()
-    window.location.reload()
+    return cancellingIncompleteDeploy()
+      .then(result => {
+        if (result.value) {
+          localStorage.clear()
+          window.location.reload()
+        }
+      })
   }
 
   render() {

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -53,7 +53,9 @@ export class stepFour extends React.Component {
   componentDidMount () {
     scrollToBottom()
     copy('copy')
-    this.showModal()
+    if (!this.props.deploymentStore.deploymentHasFinished) {
+      this.showModal()
+    }
 
     if (process.env.NODE_ENV !== 'development') this.deployCrowdsale()
   }

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -54,7 +54,7 @@ export class stepFour extends React.Component {
   componentDidMount () {
     scrollToBottom()
     copy('copy')
-    if (!this.props.deploymentStore.deploymentHasFinished) {
+    if (!this.props.deploymentStore.hasEnded) {
       this.showModal()
     }
 
@@ -84,8 +84,13 @@ export class stepFour extends React.Component {
     executeSequentially(deploymentSteps, startAt, (index) => {
       deploymentStore.setDeploymentStep(index)
     })
-      .then(() => this.hideModal())
-      .then(() => successfulDeployment())
+      .then(() => {
+        this.hideModal()
+
+        deploymentStore.setHasEnded(true)
+
+        return successfulDeployment()
+      })
       .catch(this.handleError)
   }
 

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -41,7 +41,8 @@ export class stepFour extends React.Component {
     super(props)
     this.state = {
       contractDownloaded: false,
-      modal: false
+      modal: false,
+      transactionFailed: false
     }
   }
 
@@ -91,16 +92,30 @@ export class stepFour extends React.Component {
   handleError = ([err, failedAt]) => {
     const { deploymentStore } = this.props
 
+    this.setState({
+      transactionFailed: true
+    })
+
     if (!deploymentStore.deploymentHasFinished) {
       toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.TRANSACTION_FAILED, options: {time: 1000} })
       deploymentStore.setDeploymentStep(failedAt)
-
     } else {
       this.hideModal()
       toast.showToaster({ type: TOAST.TYPE.ERROR, message: TOAST.MESSAGE.TRANSACTION_FAILED })
     }
 
     console.error([failedAt, err])
+  }
+
+  skipTransaction = () => {
+    const { deploymentStore } = this.props
+
+    this.setState({
+      transactionFailed: false
+    })
+
+    deploymentStore.setDeploymentStep(deploymentStore.deploymentStep + 1)
+    this.resumeContractDeployment()
   }
 
   hideModal = () => {
@@ -460,7 +475,11 @@ export class stepFour extends React.Component {
           title={'Tx Status'}
           showModal={this.state.modal}
         >
-          <TxProgressStatus txMap={deploymentStore.txMap} deployCrowdsale={this.deployCrowdsale} />
+          <TxProgressStatus
+            txMap={deploymentStore.txMap}
+            deployCrowdsale={this.deployCrowdsale}
+            onSkip={this.state.transactionFailed ? this.skipTransaction : null}
+          />
         </ModalContainer>
         <PreventRefresh/>
       </section>

--- a/src/stores/DeploymentStore.js
+++ b/src/stores/DeploymentStore.js
@@ -4,6 +4,7 @@ import autosave from './autosave'
 class DeploymentStore {
   @observable txMap = new Map()
   @observable deploymentStep = null
+  @observable hasEnded = false
 
   constructor() {
     autosave(this, 'DeploymentStore', (store) => {
@@ -73,6 +74,10 @@ class DeploymentStore {
 
   @action resetDeploymentStep = () => {
     this.deploymentStep = null
+  }
+
+  @action setHasEnded(value) {
+    this.hasEnded = value
   }
 
   logTxMap = () => {

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -103,8 +103,8 @@ export function warningOnMainnetAlert(tiersCount, priceSelected, reservedCount, 
   sweetAlert2({
     title: "Warning",
     html: `You are about to sign ${estimatedTxsCount} TXs. You will see an individual Metamask windows for each of it.
-     Please don't open two or more instances of Wizard in one browser. Token Wizard will create ${tiersCount}-tier(s) 
-     crowdsale for you. The total cost will be around ${estimatedCost.toFixed(2)} ETH. Are you sure you want to 
+     Please don't open two or more instances of Wizard in one browser. Token Wizard will create ${tiersCount}-tier(s)
+     crowdsale for you. The total cost will be around ${estimatedCost.toFixed(2)} ETH. Are you sure you want to
      proceed?`,
     type: "warning",
     showCancelButton: true,
@@ -179,4 +179,16 @@ export function mainnetIsOnMaintenance() {
     html: "Token Wizard on Mainnet is down for maintenance. For updates, please check <a href='https://gitter.im/poanetwork/token-wizard'>our gitter</a>",
     type: "warning"
   });
+}
+
+export function cancellingIncompleteDeploy() {
+  return sweetAlert2({
+    title: "Cancel crowdsale deploy",
+    html: "Are you sure you want to cancel the deployment of the crowdsale? This action cannot be undone.",
+    type: "warning",
+    showCancelButton: true,
+    cancelButtonText: "No",
+    confirmButtonText: "Yes",
+    reverseButtons: true
+  })
 }


### PR DESCRIPTION
Depends on #594.

This is the last part of #529. If this is approved, I will create a PR for the feature branch against master.

Show a skip button if a transaction fails. This is a workaround for the problem of repeated transactions. The scenario is this: suppose that a transaction can only be done once, and it fails if it's repeated. Suppose too that the deploy is in a step that performs a transaction like that. Then:

1. MetaMask shows the popup for submitting that transaction.
2. The user's browser crashes or they refresh the page.
3. The deployment is resumed, and the same transaction is sent through MetaMask. Now MetaMask has two equal transactions in the queue, but the app only responds to the result of the second one.
4. The user submits both transactions. The first one is successful, but the app doesn't know it. The second one fails, and the app stops the deployment. If the user refreshes the page to resume the deploy, the transaction will be tried again, but it will continue to fail.

In that scenario, skipping that transaction makes sense if the user knows that the transaction was executed even if the app doesn't know it.