### PR TITLE
(Fix) check isMined on error event

### DIFF
--- a/src/utils/blockchainHelpers.js
+++ b/src/utils/blockchainHelpers.js
@@ -152,6 +152,7 @@ let sendTX = (method, type) => {
   return new Promise((resolve, reject) => {
     method
       .on('error', error => {
+        if (isMined) return
         console.error(error)
         // https://github.com/poanetwork/token-wizard/issues/472
         if (


### PR DESCRIPTION
We shouldn't handle an error from the previous deployment tx, if it is already mined in `repeatPolling()` of tx receipt. Possible fix for https://github.com/poanetwork/token-wizard/issues/603