### PR TITLE
(Fix) Add validation to decimals

### DIFF
--- a/src/components/Common/InputField.js
+++ b/src/components/Common/InputField.js
@@ -24,6 +24,7 @@ export const InputField = props => {
         onBlur={props.onBlur}
         value={props.value}
         onChange={props.onChange}
+        onKeyPress={props.onKeyPress}
       />
       <p className="description">{props.description}</p>
       { props.pristine ? null : <p style={errorStyle}>{error}</p> }

--- a/src/components/Common/NumericInput.js
+++ b/src/components/Common/NumericInput.js
@@ -1,0 +1,92 @@
+import React, { Component } from 'react'
+import { InputField } from './InputField'
+import { VALIDATION_TYPES } from '../../utils/constants'
+import update from 'immutability-helper'
+import { observer } from 'mobx-react'
+import { countDecimalPlaces } from '../../utils/utils'
+
+const { VALID, INVALID } = VALIDATION_TYPES
+
+@observer
+export class NumericInput extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      value: '',
+      validation: {
+        value: {
+          pristine: true,
+          valid: INVALID
+        }
+      }
+    }
+  }
+
+  onKeyPress = e => {
+    if (!this.props.acceptFloat) {
+      if (isNaN(parseInt(e.key, 10))) e.preventDefault()
+    }
+  }
+
+  onChange = e => {
+    const { value } = e.target
+    let isValid = true
+
+    if (this.props.min) {
+      isValid = isValid && value >= parseFloat(this.props.min)
+    }
+
+    if (isValid && this.props.max) {
+      isValid = isValid && value <= parseFloat(this.props.max)
+    }
+
+    if (isValid && this.props.acceptFloat) {
+      if (this.props.maxDecimals) {
+        isValid = isValid && countDecimalPlaces(value) <= this.props.maxDecimals
+      }
+
+      if (this.props.minDecimals) {
+        isValid = isValid && countDecimalPlaces(value) >= this.props.minDecimals
+      }
+    }
+
+    if (value === '') {
+      isValid = true
+    }
+
+    const newValue = value === '' ? '' : parseFloat(value)
+    const newState = update(this.state, {
+      validation: {
+        $set: {
+          value: {
+            pristine: false,
+            valid: isValid ? VALID : INVALID
+          }
+        }
+      }
+    })
+    newState.value = newValue
+
+    this.setState(newState, () => {
+      this.props.onValueUpdate(newValue)
+    })
+  }
+
+  render () {
+    return (
+      <InputField
+        side={this.props.side}
+        type='number'
+        errorMessage={this.props.errorMessage}
+        valid={this.state.validation.value.valid}
+        pristine={this.state.validation.value.pristine}
+        value={this.state.value}
+        title={this.props.title}
+        onKeyPress={e => this.onKeyPress(e)}
+        onChange={e => this.onChange(e)}
+        description={this.props.description}
+      />
+    )
+  }
+}

--- a/src/components/Common/NumericInput.js
+++ b/src/components/Common/NumericInput.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { InputField } from './InputField'
 import { VALIDATION_TYPES } from '../../utils/constants'
-import update from 'immutability-helper'
 import { observer } from 'mobx-react'
 import { countDecimalPlaces } from '../../utils/utils'
 
@@ -14,12 +13,8 @@ export class NumericInput extends Component {
 
     this.state = {
       value: '',
-      validation: {
-        value: {
-          pristine: true,
-          valid: INVALID
-        }
-      }
+      pristine: true,
+      valid: INVALID
     }
   }
 
@@ -56,21 +51,11 @@ export class NumericInput extends Component {
     }
 
     const newValue = value === '' ? '' : parseFloat(value)
-    const newState = update(this.state, {
-      validation: {
-        $set: {
-          value: {
-            pristine: false,
-            valid: isValid ? VALID : INVALID
-          }
-        }
-      }
-    })
-    newState.value = newValue
-
-    this.setState(newState, () => {
-      this.props.onValueUpdate(newValue)
-    })
+    this.setState({
+      pristine: false,
+      valid: isValid ? VALID : INVALID,
+      value: newValue
+    }, () => this.props.onValueUpdate(newValue))
   }
 
   render () {
@@ -79,8 +64,8 @@ export class NumericInput extends Component {
         side={this.props.side}
         type='number'
         errorMessage={this.props.errorMessage}
-        valid={this.state.validation.value.valid}
-        pristine={this.state.validation.value.pristine}
+        valid={this.state.valid}
+        pristine={this.state.pristine}
         value={this.state.value}
         title={this.props.title}
         onKeyPress={e => this.onKeyPress(e)}

--- a/src/components/Common/NumericInput.spec.js
+++ b/src/components/Common/NumericInput.spec.js
@@ -86,6 +86,16 @@ describe('NumericInput', () => {
     expect(wrapper.state('validation').value.valid).toBe(VALID)
   })
 
+  it('Should consider empty string as valid', () => {
+    const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+    const input = wrapper.find('input').at(0)
+
+    input.simulate('change', mock)
+    expect(numericInputComponent.onValueUpdate).toHaveBeenCalled()
+    expect(wrapper.state('validation').value.valid).toBe(VALID)
+    expect(wrapper.state('validation').value.pristine).toBeFalsy()
+  })
+
   it('Should call onValueUpdate callback on successful update', () => {
     const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
     const input = wrapper.find('input').at(0)
@@ -103,6 +113,68 @@ describe('NumericInput', () => {
   })
 
   describe('float numbers', () => {
+    it ('Should validate maxDecimals', () => {
+      numericInputComponent.acceptFloat = true
+      numericInputComponent.maxDecimals = '4'
+      const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+      const input = wrapper.find('input').at(0)
+
+      mock.target.value = '1.12345'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+
+      mock.target.value = '1.1234'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(VALID)
+    })
+
+    it ('Should validate minDecimals', () => {
+      numericInputComponent.acceptFloat = true
+      numericInputComponent.minDecimals = '2'
+      const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+      const input = wrapper.find('input').at(0)
+
+      mock.target.value = '1.1'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+
+      mock.target.value = '1.1234'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(VALID)
+    })
+
+    it ('Should validate minDecimals and maxDecimals', () => {
+      numericInputComponent.acceptFloat = true
+      numericInputComponent.maxDecimals = '4'
+      numericInputComponent.minDecimals = '2'
+      const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+      const input = wrapper.find('input').at(0)
+
+      mock.target.value = '1.1'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+
+      mock.target.value = '1.12345'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+
+      mock.target.value = '1.12'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(VALID)
+
+      mock.target.value = '1.123'
+      input.simulate('change', mock)
+      expect(wrapper.state('validation').value.pristine).toBeFalsy()
+      expect(wrapper.state('validation').value.valid).toBe(VALID)
+    })
+
     it('Should reject float with dot notation', () => {
       const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
       const input = wrapper.find('input').at(0)

--- a/src/components/Common/NumericInput.spec.js
+++ b/src/components/Common/NumericInput.spec.js
@@ -1,0 +1,157 @@
+import React from 'react'
+import { NumericInput } from './NumericInput'
+import { TEXT_FIELDS, VALIDATION_MESSAGES, VALIDATION_TYPES } from '../../utils/constants'
+import renderer from 'react-test-renderer'
+import Adapter from 'enzyme-adapter-react-15'
+import { configure, mount, shallow } from 'enzyme'
+
+const { VALID, INVALID } = VALIDATION_TYPES
+
+let mock
+let keypressMock
+let numericInputComponent
+
+configure({ adapter: new Adapter() })
+
+beforeEach(() => {
+  mock = { target: { value: '' } }
+
+  keypressMock = { key: '1', preventDefault: jest.fn() }
+
+  numericInputComponent = {
+    side: 'left',
+    title: TEXT_FIELDS.DECIMALS,
+    description:
+      'Refers to how divisible a token can be, from 0 (not at all divisible) to 18 (pretty much continuous).',
+    errorMessage: VALIDATION_MESSAGES.DECIMALS,
+    onValueUpdate: jest.fn()
+  }
+})
+
+describe('NumericInput', () => {
+  it('Should render the component', () => {
+    numericInputComponent.min = '0'
+    numericInputComponent.max = '18'
+    numericInputComponent.acceptFloat = true
+    numericInputComponent.minDecimals = '0'
+    numericInputComponent.maxDecimals = '4'
+
+    const component = renderer.create(React.createElement(NumericInput, numericInputComponent))
+    const tree = component.toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('Should validate min', () => {
+    numericInputComponent.min = 5
+    const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+    const input = wrapper.find('input').at(0)
+
+    mock.target.value = '4'
+    const expectedInvalidValue = parseFloat(mock.target.value)
+
+    input.simulate('change', mock)
+    expect(wrapper.state('value')).toBe(expectedInvalidValue)
+    expect(wrapper.state('validation').value.pristine).toBeFalsy()
+    expect(wrapper.state('validation').value.valid).toBe(INVALID)
+
+    mock.target.value = '8'
+    const expectedValidValue = parseFloat(mock.target.value)
+
+    input.simulate('change', mock)
+    expect(wrapper.state('value')).toBe(expectedValidValue)
+    expect(wrapper.state('validation').value.pristine).toBeFalsy()
+    expect(wrapper.state('validation').value.valid).toBe(VALID)
+  })
+
+  it('Should validate max', () => {
+    numericInputComponent.max = 15
+    const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+    const input = wrapper.find('input').at(0)
+
+    mock.target.value = '20'
+    const expectedInvalidValue = parseFloat(mock.target.value)
+
+    input.simulate('change', mock)
+    expect(wrapper.state('value')).toBe(expectedInvalidValue)
+    expect(wrapper.state('validation').value.pristine).toBeFalsy()
+    expect(wrapper.state('validation').value.valid).toBe(INVALID)
+
+    mock.target.value = '10'
+    const expectedValidValue = parseFloat(mock.target.value)
+
+    input.simulate('change', mock)
+    expect(wrapper.state('value')).toBe(expectedValidValue)
+    expect(wrapper.state('validation').value.pristine).toBeFalsy()
+    expect(wrapper.state('validation').value.valid).toBe(VALID)
+  })
+
+  it('Should call onValueUpdate callback on successful update', () => {
+    const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+    const input = wrapper.find('input').at(0)
+
+    mock.target.value = '10'
+    const expectedValue = parseFloat(mock.target.value)
+
+    input.simulate('change', mock)
+    expect(wrapper.state('value')).toBe(expectedValue)
+    expect(wrapper.state('validation').value.pristine).toBeFalsy()
+    expect(wrapper.state('validation').value.valid).toBe(VALID)
+
+    expect(numericInputComponent.onValueUpdate).toHaveBeenCalledTimes(1)
+    expect(numericInputComponent.onValueUpdate).toHaveBeenCalledWith(expectedValue)
+  })
+
+  describe('float numbers', () => {
+    it('Should reject float with dot notation', () => {
+      const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+      const input = wrapper.find('input').at(0)
+
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
+
+      keypressMock.key = '.'
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalled()
+    })
+
+    it('Should accept float with dot notation', () => {
+      numericInputComponent.acceptFloat = true
+      const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+      const input = wrapper.find('input').at(0)
+
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
+
+      keypressMock.key = '.'
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
+    })
+
+    it('Should reject float with scientific notation', () => {
+      const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+      const input = wrapper.find('input').at(0)
+
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
+
+      keypressMock.key = 'e'
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalled()
+    })
+
+    it('Should accept float with scientific notation', () => {
+      numericInputComponent.acceptFloat = true
+      const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
+      const input = wrapper.find('input').at(0)
+
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
+
+      keypressMock.key = 'e'
+      input.simulate('keypress', keypressMock)
+      expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
+    })
+
+  })
+})

--- a/src/components/Common/NumericInput.spec.js
+++ b/src/components/Common/NumericInput.spec.js
@@ -5,7 +5,15 @@ import renderer from 'react-test-renderer'
 import Adapter from 'enzyme-adapter-react-15'
 import { configure, mount, shallow } from 'enzyme'
 
-const { VALID, INVALID } = VALIDATION_TYPES
+const COMPONENT_STATE = {
+  VALUE: 'value',
+  PRISTINE: 'pristine',
+  VALID: 'valid'
+}
+const INPUT_EVENT = {
+  KEYPRESS: 'keypress',
+  CHANGE: 'change'
+}
 
 let mock
 let keypressMock
@@ -50,18 +58,18 @@ describe('NumericInput', () => {
     mock.target.value = '4'
     const expectedInvalidValue = parseFloat(mock.target.value)
 
-    input.simulate('change', mock)
-    expect(wrapper.state('value')).toBe(expectedInvalidValue)
-    expect(wrapper.state('validation').value.pristine).toBeFalsy()
-    expect(wrapper.state('validation').value.valid).toBe(INVALID)
+    input.simulate(INPUT_EVENT.CHANGE, mock)
+    expect(wrapper.state(COMPONENT_STATE.VALUE)).toBe(expectedInvalidValue)
+    expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+    expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.INVALID)
 
     mock.target.value = '8'
     const expectedValidValue = parseFloat(mock.target.value)
 
-    input.simulate('change', mock)
-    expect(wrapper.state('value')).toBe(expectedValidValue)
-    expect(wrapper.state('validation').value.pristine).toBeFalsy()
-    expect(wrapper.state('validation').value.valid).toBe(VALID)
+    input.simulate(INPUT_EVENT.CHANGE, mock)
+    expect(wrapper.state(COMPONENT_STATE.VALUE)).toBe(expectedValidValue)
+    expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+    expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
   })
 
   it('Should validate max', () => {
@@ -72,28 +80,28 @@ describe('NumericInput', () => {
     mock.target.value = '20'
     const expectedInvalidValue = parseFloat(mock.target.value)
 
-    input.simulate('change', mock)
-    expect(wrapper.state('value')).toBe(expectedInvalidValue)
-    expect(wrapper.state('validation').value.pristine).toBeFalsy()
-    expect(wrapper.state('validation').value.valid).toBe(INVALID)
+    input.simulate(INPUT_EVENT.CHANGE, mock)
+    expect(wrapper.state(COMPONENT_STATE.VALUE)).toBe(expectedInvalidValue)
+    expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+    expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.INVALID)
 
     mock.target.value = '10'
     const expectedValidValue = parseFloat(mock.target.value)
 
-    input.simulate('change', mock)
-    expect(wrapper.state('value')).toBe(expectedValidValue)
-    expect(wrapper.state('validation').value.pristine).toBeFalsy()
-    expect(wrapper.state('validation').value.valid).toBe(VALID)
+    input.simulate(INPUT_EVENT.CHANGE, mock)
+    expect(wrapper.state(COMPONENT_STATE.VALUE)).toBe(expectedValidValue)
+    expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+    expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
   })
 
   it('Should consider empty string as valid', () => {
     const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
     const input = wrapper.find('input').at(0)
 
-    input.simulate('change', mock)
+    input.simulate(INPUT_EVENT.CHANGE, mock)
     expect(numericInputComponent.onValueUpdate).toHaveBeenCalled()
-    expect(wrapper.state('validation').value.valid).toBe(VALID)
-    expect(wrapper.state('validation').value.pristine).toBeFalsy()
+    expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
+    expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
   })
 
   it('Should call onValueUpdate callback on successful update', () => {
@@ -103,10 +111,10 @@ describe('NumericInput', () => {
     mock.target.value = '10'
     const expectedValue = parseFloat(mock.target.value)
 
-    input.simulate('change', mock)
-    expect(wrapper.state('value')).toBe(expectedValue)
-    expect(wrapper.state('validation').value.pristine).toBeFalsy()
-    expect(wrapper.state('validation').value.valid).toBe(VALID)
+    input.simulate(INPUT_EVENT.CHANGE, mock)
+    expect(wrapper.state(COMPONENT_STATE.VALUE)).toBe(expectedValue)
+    expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+    expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
 
     expect(numericInputComponent.onValueUpdate).toHaveBeenCalledTimes(1)
     expect(numericInputComponent.onValueUpdate).toHaveBeenCalledWith(expectedValue)
@@ -120,14 +128,14 @@ describe('NumericInput', () => {
       const input = wrapper.find('input').at(0)
 
       mock.target.value = '1.12345'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.INVALID)
 
       mock.target.value = '1.1234'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(VALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
     })
 
     it ('Should validate minDecimals', () => {
@@ -137,14 +145,14 @@ describe('NumericInput', () => {
       const input = wrapper.find('input').at(0)
 
       mock.target.value = '1.1'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.INVALID)
 
       mock.target.value = '1.1234'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(VALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
     })
 
     it ('Should validate minDecimals and maxDecimals', () => {
@@ -155,35 +163,35 @@ describe('NumericInput', () => {
       const input = wrapper.find('input').at(0)
 
       mock.target.value = '1.1'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.INVALID)
 
       mock.target.value = '1.12345'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(INVALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.INVALID)
 
       mock.target.value = '1.12'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(VALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
 
       mock.target.value = '1.123'
-      input.simulate('change', mock)
-      expect(wrapper.state('validation').value.pristine).toBeFalsy()
-      expect(wrapper.state('validation').value.valid).toBe(VALID)
+      input.simulate(INPUT_EVENT.CHANGE, mock)
+      expect(wrapper.state(COMPONENT_STATE.PRISTINE)).toBeFalsy()
+      expect(wrapper.state(COMPONENT_STATE.VALID)).toBe(VALIDATION_TYPES.VALID)
     })
 
     it('Should reject float with dot notation', () => {
       const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
       const input = wrapper.find('input').at(0)
 
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
 
       keypressMock.key = '.'
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalled()
     })
 
@@ -192,11 +200,11 @@ describe('NumericInput', () => {
       const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
       const input = wrapper.find('input').at(0)
 
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
 
       keypressMock.key = '.'
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
     })
 
@@ -204,11 +212,11 @@ describe('NumericInput', () => {
       const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
       const input = wrapper.find('input').at(0)
 
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
 
       keypressMock.key = 'e'
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalled()
     })
 
@@ -217,11 +225,11 @@ describe('NumericInput', () => {
       const wrapper = mount(React.createElement(NumericInput, numericInputComponent))
       const input = wrapper.find('input').at(0)
 
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
 
       keypressMock.key = 'e'
-      input.simulate('keypress', keypressMock)
+      input.simulate(INPUT_EVENT.KEYPRESS, keypressMock)
       expect(keypressMock.preventDefault).toHaveBeenCalledTimes(0)
     })
 

--- a/src/components/Common/__snapshots__/NumericInput.spec.js.snap
+++ b/src/components/Common/__snapshots__/NumericInput.spec.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NumericInput Should render the component 1`] = `
+<div
+  className="left"
+>
+  <label
+    className="label"
+  >
+    Decimals
+  </label>
+  <input
+    className="input"
+    disabled={undefined}
+    onBlur={undefined}
+    onChange={[Function]}
+    onKeyPress={[Function]}
+    type="number"
+    value=""
+  />
+  <p
+    className="description"
+  >
+    Refers to how divisible a token can be, from 0 (not at all divisible) to 18 (pretty much continuous).
+  </p>
+</div>
+`;

--- a/src/components/Common/__snapshots__/ReservedTokensInputBlock.spec.js.snap
+++ b/src/components/Common/__snapshots__/ReservedTokensInputBlock.spec.js.snap
@@ -23,6 +23,7 @@ exports[`ReservedTokensInputBlock Should render the component 1`] = `
           disabled={undefined}
           onBlur={undefined}
           onChange={[Function]}
+          onKeyPress={undefined}
           type="text"
           value=""
         />
@@ -93,6 +94,7 @@ exports[`ReservedTokensInputBlock Should render the component 1`] = `
           disabled={undefined}
           onBlur={undefined}
           onChange={[Function]}
+          onKeyPress={undefined}
           type="number"
           value=""
         />

--- a/src/components/stepTwo/index.js
+++ b/src/components/stepTwo/index.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { checkWeb3 } from '../../utils/blockchainHelpers'
 import { StepNavigation } from '../Common/StepNavigation'
 import { InputField } from '../Common/InputField'
+import { NumericInput } from '../Common/NumericInput'
 import { ReservedTokensInputBlock } from '../Common/ReservedTokensInputBlock'
 import { NAVIGATION_STEPS, VALIDATION_MESSAGES, TEXT_FIELDS, DESCRIPTION } from '../../utils/constants'
 import { inject, observer } from 'mobx-react';
@@ -25,6 +26,10 @@ export class stepTwo extends Component {
     const value = event.target.value;
     this.props.tokenStore.setProperty(property, value);
     this.props.tokenStore.validateTokens(property);
+  }
+
+  updateDecimalsStore = value => {
+    this.updateTokenStore({ target: { value } }, 'decimals')
   }
 
   renderLink () {
@@ -76,14 +81,14 @@ export class stepTwo extends Component {
               onChange={(e) => this.updateTokenStore(e, 'ticker')}
               description={`${DESCRIPTION.TOKEN_TICKER} There are 11,881,376 combinations for 26 english letters. Be hurry. `}
             />
-            <InputField
-              side='left' type='number'
-              errorMessage={VALIDATION_MESSAGES.DECIMALS}
-              valid={this.props.tokenStore.validToken['decimals']}
+            <NumericInput
+              side="left"
               title={DECIMALS}
-              value={this.props.tokenStore.decimals}
-              onChange={(e) => this.updateTokenStore(e, 'decimals')} // changeInputField
-              description={`Refers to how divisible a token can be, from 0 (not at all divisible) to 18 (pretty much continuous).`}
+              description="Refers to how divisible a token can be, from 0 (not at all divisible) to 18 (pretty much continuous)."
+              min="0"
+              max="18"
+              errorMessage={VALIDATION_MESSAGES.DECIMALS}
+              onValueUpdate={this.updateDecimalsStore}
             />
           </div>
           <div className="reserved-tokens-title">

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -203,7 +203,7 @@ export const validateName = (name) => typeof name === 'string' && name.length > 
 
 export const validateSupply = (supply) =>  isNaN(Number(supply)) === false && Number(supply) > 0
 
-export const validateDecimals = (decimals) => isNaN(Number(decimals)) === false && Number(decimals) >= 0 && Number(decimals) <= 18
+export const validateDecimals = (decimals) => /^$|^([0-9]|[1][0-8])$/.test(decimals)
 
 export const validateTicker = (ticker) => typeof ticker === 'string' && ticker.length <= 5 && ticker.length > 0
 
@@ -337,3 +337,15 @@ export const displayHeaderAndFooterInIframe = () => {
   const insideAnIframe = window.self !== window.top
   return insideAnIframe ? CrowdsaleConfig.showHeaderAndFooterInIframe : true
 }
+
+export const countDecimalPlaces = num => {
+  const match = ('' + num).match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/)
+
+  if (!match) return 0
+
+  const digitsAfterDecimal = match[1] ? match[1].length : 0
+  const adjust = match[2] ? +match[2] : 0
+
+  return Math.max(0, digitsAfterDecimal - adjust)
+}
+

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -339,6 +339,17 @@ export const displayHeaderAndFooterInIframe = () => {
 }
 
 export const countDecimalPlaces = num => {
+  /*
+    (?:
+      \.
+      (\d+)  First captured group: decimals after the point but before the e
+    )?
+    (?:
+      [eE]
+      ([+-]?\d+)  Second captured group: exponent used to adjust the count
+    )?
+    $
+  */
   const match = ('' + num).match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/)
 
   if (!match) return 0

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -352,7 +352,7 @@ export const countDecimalPlaces = num => {
   */
   const match = ('' + num).match(/(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/)
 
-  if (!match) return 0
+  if (!match[0] && !match[1] && !match[2]) return 0
 
   const digitsAfterDecimal = match[1] ? match[1].length : 0
   const adjust = match[2] ? +match[2] : 0

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -1,0 +1,19 @@
+import { countDecimalPlaces } from './utils'
+
+describe('countDecimalPlaces', () => {
+  it('Should count decimals with dot notation', () => {
+    expect(countDecimalPlaces('1.123')).toBe(3)
+    expect(countDecimalPlaces('1.12')).toBe(2)
+    expect(countDecimalPlaces('1.')).toBe(0)
+    expect(countDecimalPlaces('1')).toBe(0)
+  })
+
+  it('Should count decimals with scientific notation', () => {
+    expect(countDecimalPlaces('1e-3')).toBe(3)
+    expect(countDecimalPlaces('1e-2')).toBe(2)
+    expect(countDecimalPlaces('1.2e-2')).toBe(3)
+    expect(countDecimalPlaces('1.e-2')).toBe(2)
+    expect(countDecimalPlaces('1.23123e2')).toBe(3)
+    expect(countDecimalPlaces('123.123e+2')).toBe(1)
+  })
+})

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -6,6 +6,7 @@ describe('countDecimalPlaces', () => {
     expect(countDecimalPlaces('1.12')).toBe(2)
     expect(countDecimalPlaces('1.')).toBe(0)
     expect(countDecimalPlaces('1')).toBe(0)
+    expect(countDecimalPlaces('.123')).toBe(3)
   })
 
   it('Should count decimals with scientific notation', () => {

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -16,5 +16,22 @@ describe('countDecimalPlaces', () => {
     expect(countDecimalPlaces('1.e-2')).toBe(2)
     expect(countDecimalPlaces('1.23123e2')).toBe(3)
     expect(countDecimalPlaces('123.123e+2')).toBe(1)
+    expect(countDecimalPlaces('.2e-2')).toBe(3)
+  })
+
+  it('Should return zero when parameter is an integer', () => {
+    expect(countDecimalPlaces('1')).toBe(0)
+    expect(countDecimalPlaces('123')).toBe(0)
+    expect(countDecimalPlaces('0')).toBe(0)
+    expect(countDecimalPlaces('-123')).toBe(0)
+  })
+
+  it('Should return zero when parameter is not a valid number', () => {
+    expect(countDecimalPlaces('abc')).toBe(0)
+    expect(countDecimalPlaces('e')).toBe(0)
+    expect(countDecimalPlaces('')).toBe(0)
+    expect(countDecimalPlaces(null)).toBe(0)
+    expect(countDecimalPlaces(false)).toBe(0)
+    expect(countDecimalPlaces(undefined)).toBe(0)
   })
 })


### PR DESCRIPTION
Closes #568 

Created a new component (`NumericInput`) whose intention is to be used across all the wizard where a number is required.

I just updated the **DECIMALS** input field for `stepTwo` with this new component