### PR TITLE
(Fix) Don't continue to step 4 if min cap is not valid

### DIFF
--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -139,7 +139,7 @@ export class stepThree extends React.Component {
 
     const { tierStore, gasPriceStore } = this.props;
     const gasPriceIsValid = gasPriceStore.custom.id !== this.state.gasPriceSelected || this.state.validation.gasPrice.valid === VALID
-    const isMinCapValid = tierStore.globalMinCap <= tierStore.minSupply
+    const isMinCapValid = tierStore.globalMinCap <= tierStore.maxSupply
 
     for (let index = 0; index < tierStore.tiers.length; index++) {
       tierStore.validateTiers("endTime", index);

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -139,15 +139,24 @@ export class stepThree extends React.Component {
 
     const { tierStore, gasPriceStore } = this.props;
     const gasPriceIsValid = gasPriceStore.custom.id !== this.state.gasPriceSelected || this.state.validation.gasPrice.valid === VALID
-
-    console.log('gasPriceIsValid', gasPriceIsValid)
+    const isMinCapValid = tierStore.globalMinCap <= tierStore.minSupply
 
     for (let index = 0; index < tierStore.tiers.length; index++) {
       tierStore.validateTiers("endTime", index);
       tierStore.validateTiers("startTime", index);
     }
 
-    if (tierStore.areTiersValid && gasPriceIsValid) {
+    if (!isMinCapValid) {
+      this.setState(update(this.state, {
+        validation: {
+          minCap: {
+            valid: { $set: INVALID }
+          }
+        }
+      }))
+    }
+
+    if (tierStore.areTiersValid && gasPriceIsValid && isMinCapValid) {
       const { reservedTokenStore, deploymentStore } = this.props
       const tiersCount = tierStore.tiers.length
       const reservedCount = reservedTokenStore.tokens.length

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -2,7 +2,7 @@ import { observable, action, computed } from 'mobx';
 import { VALIDATION_TYPES, defaultTiers } from '../utils/constants'
 import {
   validateName, validateTime, validateSupply, validateRate, validateAddress, validateLaterTime,
-  validateLaterOrEqualTime, validateTier, validateMinCap
+  validateLaterOrEqualTime, validateTier
 } from '../utils/utils'
 import autosave from './autosave'
 const { VALID, INVALID } = VALIDATION_TYPES
@@ -193,7 +193,7 @@ class TierStore {
   }
 
   @computed get maxSupply () {
-    return this.tiers.map(tier => +tier.supply).reduce((a, b) => Math.max(a, b))
+    return this.tiers.map(tier => +tier.supply).reduce((a, b) => Math.max(a, b), 0)
   }
 }
 

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -192,8 +192,8 @@ class TierStore {
     this.setTierProperty(whitelist, 'whitelist', crowdsaleNum)
   }
 
-  @computed get minSupply () {
-    return this.tiers.map(tier => +tier.supply).reduce((a, b) => Math.min(a, b))
+  @computed get maxSupply () {
+    return this.tiers.map(tier => +tier.supply).reduce((a, b) => Math.max(a, b))
   }
 }
 

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -191,6 +191,10 @@ class TierStore {
     whitelist[whitelistNum].deleted = true
     this.setTierProperty(whitelist, 'whitelist', crowdsaleNum)
   }
+
+  @computed get minSupply () {
+    return this.tiers.map(tier => +tier.supply).reduce((a, b) => Math.min(a, b))
+  }
 }
 
 export default TierStore;

--- a/src/stores/TierStore.spec.js
+++ b/src/stores/TierStore.spec.js
@@ -1,0 +1,37 @@
+import TierStore from './TierStore'
+
+describe('TierStore', () => {
+  describe('maxSupply', () => {
+    const testCases = [{
+      tiers: [],
+      expected: 0
+    }, {
+      tiers: [5],
+      expected: 5
+    }, {
+      tiers: [5, 10],
+      expected: 10
+    }, {
+      tiers: [10, 5],
+      expected: 10
+    }, {
+      tiers: [10, 10],
+      expected: 10
+    }]
+
+    testCases.forEach(({ tiers, expected }) => {
+      it(`should get the max supply for tiers ${JSON.stringify(tiers)}`, () => {
+        const tierStore = new TierStore()
+
+        tierStore.emptyList()
+        tiers.forEach(tier => tierStore.addTier({
+          supply: tier
+        }))
+
+        const result = tierStore.maxSupply
+
+        expect(result).toEqual(expected)
+      })
+    })
+  })
+})

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -97,7 +97,7 @@ export const VALIDATION_MESSAGES = {
   EDITED_END_TIME: 'Please enter a valid date later than start time and previous than start time of next tier',
   EDITED_START_TIME: 'Please enter a valid date later than now, less than end time and later than the end time of the previous tier',
   RATE: 'Please enter a valid number greater than 0',
-  MINCAP: 'Value must be positive, decimals should not exceed the amount of decimals specified and min cap should be less or equal than the smaller supply'
+  MINCAP: 'Value must be positive, decimals should not exceed the amount of decimals specified and min cap should be less or equal than the supply of some tier'
 }
 
 //descriptions of input fields

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -97,7 +97,7 @@ export const VALIDATION_MESSAGES = {
   EDITED_END_TIME: 'Please enter a valid date later than start time and previous than start time of next tier',
   EDITED_START_TIME: 'Please enter a valid date later than now, less than end time and later than the end time of the previous tier',
   RATE: 'Please enter a valid number greater than 0',
-  MINCAP: 'Value must be positive and decimals should not exceed the amount of decimals specified'
+  MINCAP: 'Value must be positive, decimals should not exceed the amount of decimals specified and min cap should be less or equal than the smaller supply'
 }
 
 //descriptions of input fields


### PR DESCRIPTION
Closes #621.

This checks that the min cap isn't greater than _any_ supply, not the sum of all the supplies. Otherwise, it may be the case that you can't buy in any tier.

For example, if you have a tier with supply 10 and another with supply 5, and your min cap is 11, it's less than the sum of all supplies, but you can't buy in none of the tiers.

I don't like at all the error message in this fix: it shows a message that basically says "this field is wrong, and one of these three things is the one causing the error".

It would be much better UI to show only the messages that are relevant. For example, if you input "-1" it just says "Value must be positive". If you input "1.333" and the token only has two decimals, it says "Decimals should not exceed...". If you input "-1.333", it should show both messages.

I didn't do it that way in this PR because it's a much bigger change, but if you agree with this, I will create an issue to improve it.