### PR TITLE
(Fix) Set deploymentStep when starting step four

### DIFF
--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -44,6 +44,7 @@ export class stepFour extends React.Component {
       modal: false,
       transactionFailed: false
     }
+    this.props.deploymentStore.setDeploymentStep(0)
   }
 
   contractDownloadSuccess = options => {


### PR DESCRIPTION
Fixes #593 (the underlying issue).

Switching networks may cause a lot of issues, and I'm not sure we can (or should) fix them all. For example, if you switch networks in the middle of a deployment, you'll be allowed to continue, but the deploy will of course fail.

I guess we could save the id of the network where the deployment started, and alert the user that they are in a different network. But I wouldn't try anything more clever than that (for example, persisting different incomplete deployments in the local storage according to the network that is being used).