### PR TITLE
(Fix) unify dev and prod interfaces

### DIFF
--- a/src/components/Common/TxProgressStatus.js
+++ b/src/components/Common/TxProgressStatus.js
@@ -59,12 +59,6 @@ export class TxProgressStatus extends Component {
             </div>
           </div>
           <div className="steps">
-            {process.env.NODE_ENV === 'development' && !deploymentStore.deploymentHasFinished
-              ? !deploymentStore.deploymentStep
-                ? <a onClick={this.props.deployCrowdsale} className="no_image button button_fill">Deploy!</a>
-                : <a onClick={this.props.deployCrowdsale} className="no_image button button_fill">Resume deploy...</a>
-              : null
-            }
             {this.props.onSkip
               ? <a onClick={this.props.onSkip} className="no_image button button_fill">Skip transaction</a>
               : null

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -64,7 +64,7 @@ export class stepFour extends React.Component {
       this.showModal()
     }
 
-    if (process.env.NODE_ENV !== 'development') this.deployCrowdsale()
+    this.deployCrowdsale()
   }
 
   deployCrowdsale = () => {


### PR DESCRIPTION
For now, e2e tests work with production environment and fail with dev environment. This is because of different interfaces for dev and prod. At least "Deploy" button exists in step 4 in a dev environment and it is hidden in prod environment 

![screen shot 2018-03-14 at 23 53 20](https://user-images.githubusercontent.com/4341812/37457210-5a1c7672-2852-11e8-97dd-479e229d077d.png). I see two ways:
1. create different e2e scripts for local and prod environments
2. adjust a local environment to fit prod one.

PR implements the 2nd approach.