### PR TITLE
(Fix) Make invest available even if there is no injected web3

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,31 +27,36 @@ class App extends Component {
         <div>
           <Header/>
 
-          <Web3Provider
-            onChangeAccount={deploymentStore.handleAccountChange}
-            web3UnavailableScreen={NoWeb3}
-          >
-            <Switch>
-              {/* The route to /4 must be first for the incomplete deploy redirect to work */}
-              <Route path="/4" component={stepFour}/>
+          <Switch>
+            <Route exact path="/invest" component={Invest}/>
 
-              {
-                deploymentStore.deployInProgress ? (
-                  <IncompleteDeploy />
-                ) : (
-                  <Switch>
-                    <Route exact path="/" component={crowdsaleAddr ? Crowdsale : Home}/>
-                    <Route exact path="/crowdsale" component={Crowdsale}/>
-                    <Route exact path="/invest" component={Invest}/>
-                    <Route exact path="/manage/:crowdsaleAddress" component={Manage}/>
-                    <Route path="/1" component={stepOne}/>
-                    <Route path="/2" component={stepTwo}/>
-                    <Route path="/3" component={stepThree}/>
-                  </Switch>
-                )
-              }
-            </Switch>
-          </Web3Provider>
+            <Route>
+              <Web3Provider
+                onChangeAccount={deploymentStore.handleAccountChange}
+                web3UnavailableScreen={NoWeb3}
+              >
+                <Switch>
+                  {/* The route to /4 must be first for the incomplete deploy redirect to work */}
+                  <Route path="/4" component={stepFour}/>
+
+                  {
+                    deploymentStore.deployInProgress ? (
+                      <IncompleteDeploy />
+                    ) : (
+                      <Switch>
+                        <Route exact path="/" component={crowdsaleAddr ? Crowdsale : Home}/>
+                        <Route exact path="/crowdsale" component={Crowdsale}/>
+                        <Route exact path="/manage/:crowdsaleAddress" component={Manage}/>
+                        <Route path="/1" component={stepOne}/>
+                        <Route path="/2" component={stepTwo}/>
+                        <Route path="/3" component={stepThree}/>
+                      </Switch>
+                    )
+                  }
+                </Switch>
+              </Web3Provider>
+            </Route>
+          </Switch>
 
           <Footer/>
           <AlertContainer ref={a => toast.msg = a} {...TOAST.DEFAULT_OPTIONS} />


### PR DESCRIPTION
See https://github.com/poanetwork/token-wizard/pull/680#issuecomment-376289139

This should allow users to go to the invest page without metamask.

Our routes are becoming too complex. I have some ideas on how to improve them, but for now this fix should be enough.