### PR TITLE
(Refactor) Use ReservedTokensInputBlock inside final-form

### DIFF
--- a/src/components/stepTwo/StepTwoForm.js
+++ b/src/components/stepTwo/StepTwoForm.js
@@ -3,6 +3,7 @@ import { FormSpy } from 'react-final-form'
 import { TokenName } from '../Common/TokenName'
 import { TokenTicker } from '../Common/TokenTicker'
 import { TokenDecimals } from '../Common/TokenDecimals'
+import { ReservedTokensInputBlock } from '../Common/ReservedTokensInputBlock'
 
 const errorStyle = {
   color: 'red',
@@ -12,7 +13,17 @@ const errorStyle = {
   height: '10px',
 }
 
-export const StepTwoForm = ({ id, handleSubmit, disableDecimals, updateTokenStore }) => {
+export const StepTwoForm = ({
+  id,
+  handleSubmit,
+  disableDecimals,
+  updateTokenStore,
+  tokens,
+  decimals,
+  addReservedTokensItem,
+  removeReservedToken,
+  clearAll
+}) => {
   return (
     <form id={id} onSubmit={handleSubmit}>
       <div className="hidden">
@@ -20,6 +31,21 @@ export const StepTwoForm = ({ id, handleSubmit, disableDecimals, updateTokenStor
         <TokenTicker errorStyle={errorStyle}/>
         <TokenDecimals disabled={disableDecimals} errorStyle={errorStyle}/>
       </div>
+      <div className="reserved-tokens-title">
+        <p className="title">Reserved tokens</p>
+      </div>
+      <ReservedTokensInputBlock
+        tokens={tokens}
+        decimals={decimals}
+        addReservedTokensItem={addReservedTokensItem}
+        removeReservedToken={removeReservedToken}
+        clearAll={clearAll}
+      />
+
+      <div className="button-container">
+        <a onClick={e => { e.preventDefault(); handleSubmit() }} className="button button_fill">Continue</a>
+      </div>
+
       <FormSpy
         onChange={({ values }) => {
           updateTokenStore('name', values.name)

--- a/src/components/stepTwo/StepTwoForm.spec.js
+++ b/src/components/stepTwo/StepTwoForm.spec.js
@@ -17,6 +17,7 @@ describe('StepTwoForm', () => {
         disableDecimals={false}
         updateTokenStore={jest.fn()}
         id="tokenData"
+        tokens={[]}
       />
     )
 
@@ -38,6 +39,7 @@ describe('StepTwoForm', () => {
         disableDecimals={false}
         updateTokenStore={jest.fn()}
         id="tokenData"
+        tokens={[]}
       />
     )
 
@@ -60,6 +62,7 @@ describe('StepTwoForm', () => {
         disableDecimals={false}
         updateTokenStore={jest.fn()}
         id="tokenData"
+        tokens={[]}
       />
     )
 
@@ -78,6 +81,7 @@ describe('StepTwoForm', () => {
         disableDecimals={false}
         updateTokenStore={updateTokenStore}
         id="tokenData"
+        tokens={[]}
       />
     )
 
@@ -97,6 +101,7 @@ describe('StepTwoForm', () => {
         disableDecimals={false}
         updateTokenStore={updateTokenStore}
         id="tokenData"
+        tokens={[]}
       />
     )
 
@@ -116,6 +121,7 @@ describe('StepTwoForm', () => {
         disableDecimals={false}
         updateTokenStore={updateTokenStore}
         id="tokenData"
+        tokens={[]}
       />
     )
 

--- a/src/components/stepTwo/__snapshots__/StepTwoForm.spec.js.snap
+++ b/src/components/stepTwo/__snapshots__/StepTwoForm.spec.js.snap
@@ -124,5 +124,164 @@ exports[`StepTwoForm Should render the component 1`] = `
       />
     </div>
   </div>
+  <div
+    className="reserved-tokens-title"
+  >
+    <p
+      className="title"
+    >
+      Reserved tokens
+    </p>
+  </div>
+  <div
+    className="reserved-tokens-container"
+  >
+    <div
+      className="reserved-tokens-input-container"
+    >
+      <div
+        className="reserved-tokens-input-container-inner"
+      >
+        <div
+          className="reserved-tokens-input-property reserved-tokens-input-property-left"
+        >
+          <label
+            className="label"
+          >
+            Address
+          </label>
+          <input
+            className="input"
+            disabled={undefined}
+            onBlur={undefined}
+            onChange={[Function]}
+            onKeyPress={undefined}
+            onPaste={undefined}
+            style={undefined}
+            type="text"
+            value=""
+          />
+          <p
+            className="description"
+          >
+            Address where to send reserved tokens.
+          </p>
+          <p
+            style={
+              Object {
+                "color": "red",
+                "fontSize": "12px",
+                "fontWeight": "bold",
+                "height": "10px",
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="reserved-tokens-input-property reserved-tokens-input-property-middle"
+        >
+          <label
+            className="label"
+          >
+            Dimension
+          </label>
+          <div
+            className="radios-inline"
+          >
+            <label
+              className="radio-inline"
+            >
+              <input
+                checked={true}
+                onChange={[Function]}
+                type="radio"
+                value="tokens"
+              />
+              <span
+                className="title"
+              >
+                tokens
+              </span>
+            </label>
+            <label
+              className="radio-inline"
+            >
+              <input
+                checked={false}
+                onChange={[Function]}
+                type="radio"
+                value="percentage"
+              />
+              <span
+                className="title"
+              >
+                percentage
+              </span>
+            </label>
+          </div>
+          <p
+            className="description"
+          >
+            Fixed amount or % of crowdsaled tokens. Will be deposited to the account after finalization of the crowdsale.
+          </p>
+        </div>
+        <div
+          className="reserved-tokens-input-property reserved-tokens-input-property-right"
+        >
+          <label
+            className="label"
+          >
+            Value
+          </label>
+          <input
+            className="input"
+            disabled={undefined}
+            onBlur={undefined}
+            onChange={[Function]}
+            onKeyPress={[Function]}
+            onPaste={[Function]}
+            style={undefined}
+            type="number"
+            value=""
+          />
+          <p
+            className="description"
+          >
+            Value in tokens. Don't forget to click + button for each reserved token.
+          </p>
+          <p
+            style={
+              Object {
+                "color": "red",
+                "fontSize": "12px",
+                "fontWeight": "bold",
+                "height": "10px",
+                "width": "100%",
+              }
+            }
+          />
+        </div>
+      </div>
+      <div
+        className="plus-button-container"
+      >
+        <div
+          className="button button_fill button_fill_plus"
+          onClick={[Function]}
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="button-container"
+  >
+    <a
+      className="button button_fill"
+      onClick={[Function]}
+    >
+      Continue
+    </a>
+  </div>
 </form>
 `;

--- a/src/components/stepTwo/index.js
+++ b/src/components/stepTwo/index.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react'
 import '../../assets/stylesheets/application.css'
-import { Link } from 'react-router-dom'
 import { checkWeb3 } from '../../utils/blockchainHelpers'
 import { StepNavigation } from '../Common/StepNavigation'
-import { ReservedTokensInputBlock } from '../Common/ReservedTokensInputBlock'
 import { clearingReservedTokens } from '../../utils/alerts'
 import { NAVIGATION_STEPS, VALIDATION_TYPES } from '../../utils/constants'
 import { inject, observer } from 'mobx-react'
@@ -31,15 +29,6 @@ export class stepTwo extends Component {
 
   componentDidMount() {
     checkWeb3(this.props.web3Store.web3)
-  }
-
-  beforeNavigate = (e) => {
-    e.preventDefault()
-    e.stopPropagation()
-
-    document
-      .getElementById('tokenData')
-      .dispatchEvent(new Event('submit'))
   }
 
   removeReservedToken = index => {
@@ -92,21 +81,13 @@ export class stepTwo extends Component {
             component={StepTwoForm}
             disableDecimals={!!this.props.reservedTokenStore.tokens.length}
             updateTokenStore={this.updateTokenStore}
-            id="tokenData"
-          />
-          <div className="reserved-tokens-title">
-            <p className="title">Reserved tokens</p>
-          </div>
-          <ReservedTokensInputBlock
             tokens={this.props.reservedTokenStore.tokens}
             decimals={decimals}
             addReservedTokensItem={this.addReservedTokensItem}
             removeReservedToken={this.removeReservedToken}
             clearAll={this.clearReservedTokens}
+            id="tokenData"
           />
-        </div>
-        <div className="button-container">
-          <Link onClick={e => this.beforeNavigate(e)} className="button button_fill" to="/3">Continue</Link>
         </div>
       </section>
     )}


### PR DESCRIPTION
After #719, the "Name", "Ticker" and "Decimals" field were ported to final-form. Our idea was to make the reserved tokens block with final-form too, but given how this block works, it is kind of difficult. So I just included it inside the form but without "translating" it to the final-form way of doing things.

Doing it the right way would mean having something like a group of inputs for each added token. This would be good not only because it would use the final-form features; it would also work as a solution for #486. I also think it'd be a nicer UI: you can edit each reserved token in-place, and have validation feedback if there are repeated reservations (instead of overwriting the entry, like we're doing now).