### PR TITLE
(Fix) Fix countdown not displaying days

### DIFF
--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -154,10 +154,13 @@ export class Invest extends React.Component {
       nextTick = crowdsalePageStore.extractNextTick()
       millisecondsToNextTick = nextTick.time - Date.now()
       const FIVE_MINUTES_BEFORE_TICK = moment(millisecondsToNextTick).subtract(5, 'minutes').valueOf()
+      const ONE_DAY = 24 * 3600 * 1000
 
-      setTimeout(() => {
-        this.setState({ displaySeconds: true })
-      }, FIVE_MINUTES_BEFORE_TICK)
+      if (FIVE_MINUTES_BEFORE_TICK < ONE_DAY) {
+        setTimeout(() => {
+          this.setState({ displaySeconds: true })
+        }, FIVE_MINUTES_BEFORE_TICK)
+      }
 
       timeInterval = setInterval(() => {
         const time = moment.duration(this.state.nextTick.time - Date.now())


### PR DESCRIPTION
Closes #754.

`setTimeout` may not work when the given value is greater than 2147483647 (approximately 24 days). This adds a check so that the timeout is only set if it's less than a day away.

See [this SO question](https://stackoverflow.com/questions/3468607/why-does-settimeout-break-for-large-millisecond-delay-values) for more information.