### PR TITLE
(Refactor) Migrate invest page to final-form

### DIFF
--- a/src/components/Common/InputField2.js
+++ b/src/components/Common/InputField2.js
@@ -6,9 +6,10 @@ export const InputField2 = (props) => (
     <label htmlFor={props.input.name} className="label">{props.label}</label>
     <input
       autoComplete="off"
-      className="input"
+      className={props.inputClassName ? props.inputClassName : "input"}
       type={props.type}
       disabled={props.disabled}
+      placeholder={props.placeholder}
       id={props.input.name}
       {...props.input}
     />

--- a/src/components/crowdsale/utils.js
+++ b/src/components/crowdsale/utils.js
@@ -380,9 +380,11 @@ function getTokenData () {
                 return console.log(err)
               }
 
-              console.log('balanceOf: ' + balanceOf)
-              const tokenAmountOf = crowdsalePageStore.tokenAmountOf ? crowdsalePageStore.tokenAmountOf : 0
-              crowdsalePageStore.setProperty('tokenAmountOf', tokenAmountOf + parseInt(balanceOf, 10))
+              const balance = toBigNumber(balanceOf)
+              console.log('balanceOf:', balance.toFixed())
+
+              const currentAmount = crowdsalePageStore.tokenAmountOf || 0
+              crowdsalePageStore.setProperty('tokenAmountOf', balance.plus(currentAmount).toFixed())
 
               if (propsCount === cbCount) {
                 resolve()
@@ -475,9 +477,11 @@ function getTokenData () {
                         return console.log(err)
                       }
 
-                      console.log('balanceOf:', balanceOf)
-                      const tokenAmountOf = crowdsalePageStore.tokenAmountOf ? crowdsalePageStore.tokenAmountOf : 0
-                      crowdsalePageStore.setProperty('tokenAmountOf', tokenAmountOf + parseInt(balanceOf, 10))
+                      const balance = toBigNumber(balanceOf)
+                      console.log('balanceOf:', balance.toFixed())
+
+                      const currentAmount = crowdsalePageStore.tokenAmountOf || 0
+                      crowdsalePageStore.setProperty('tokenAmountOf', balance.plus(currentAmount).toFixed())
 
                       if (propsCount === cbCount) {
                         resolve()

--- a/src/components/invest/InvestForm.js
+++ b/src/components/invest/InvestForm.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import { inject, observer } from 'mobx-react'
+import { Field, FormSpy } from 'react-final-form'
+import { INVESTMENT_OPTIONS } from '../../utils/constants'
+import { InputField2 } from '../Common/InputField2'
+import { composeValidators, isDecimalPlacesNotGreaterThan, isRequired } from '../../utils/validations'
+import classNames from 'classnames'
+
+export const InvestForm = inject('investStore', 'tokenStore')
+(observer(({ investStore, tokenStore, handleSubmit, pristine, invalid, ...props}) => {
+  const { decimals } = tokenStore
+  const { investThrough, updateInvestThrough, web3Available } = props
+
+  const contributeButtonClasses = classNames('button', 'button_fill', {
+    'button_disabled': pristine || invalid
+  })
+
+  const ContributeButton = investThrough === INVESTMENT_OPTIONS.METAMASK ?
+    <a className={contributeButtonClasses} onClick={handleSubmit}>Contribute</a> : null
+
+  const validateInvest = (value) => {
+    const decimalsErr = `Number of tokens to buy should be positive and should not exceed ${decimals} decimals.`
+    const errors = composeValidators(isRequired(), isDecimalPlacesNotGreaterThan(decimalsErr)(decimals))(value)
+    if (errors) return errors.shift()
+  }
+
+  const tokensToInvestOnChange = ({ values }) => {
+    if (values && values.invest !== undefined) {
+      investStore.setProperty('tokensToInvest', values.invest)
+    }
+  }
+
+  return (
+    <form className="invest-form" onSubmit={handleSubmit}>
+      <label className="invest-form-label">Choose amount to invest</label>
+
+      <div className="invest-form-input-container">
+        <Field
+          name="invest"
+          component={InputField2}
+          validate={validateInvest}
+          placeholder="0"
+          inputClassName="invest-form-input"
+        />
+        <FormSpy subscription={{ values: true }} onChange={tokensToInvestOnChange}/>
+        <div className="invest-form-label">TOKENS</div>
+      </div>
+
+      <div className="invest-through-container">
+        <select value={investThrough} className="invest-through" onChange={(e) => updateInvestThrough(e.target.value)}>
+          <option disabled={!web3Available} value={INVESTMENT_OPTIONS.METAMASK}>
+            Metamask {!web3Available ? ' (not available)' : null}</option>
+          <option value={INVESTMENT_OPTIONS.QR}>QR</option>
+        </select>
+        {ContributeButton}
+      </div>
+
+      <p className="description">
+        Think twice before contributing to Crowdsales. Tokens will be deposited on a wallet you used to buy tokens.
+      </p>
+    </form>
+  )
+}))

--- a/src/components/invest/InvestForm.spec.js
+++ b/src/components/invest/InvestForm.spec.js
@@ -1,0 +1,118 @@
+import React from 'react'
+import { Provider } from 'mobx-react'
+import { Form } from 'react-final-form'
+import InvestStore from '../../stores/InvestStore'
+import TokenStore from '../../stores/TokenStore'
+import { InvestForm } from './InvestForm'
+import Adapter from 'enzyme-adapter-react-15'
+import { configure, mount, shallow } from 'enzyme'
+import { INVESTMENT_OPTIONS } from '../../utils/constants'
+
+configure({ adapter: new Adapter() })
+
+describe('InvestForm', () => {
+  it(`should render InvestForm component`, () => {
+    const wrapper = shallow(
+      <Form
+        onSubmit={jest.fn()}
+        component={InvestForm}
+        investThrough={INVESTMENT_OPTIONS.METAMASK}
+        updateInvestThrough={jest.fn()}
+        web3Available={true}
+      />
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it(`should render InvestForm component and its children`, () => {
+    const investStore = new InvestStore()
+    const tokenStore = new TokenStore()
+
+    const wrapper = mount(
+      <Provider investStore={investStore} tokenStore={tokenStore}>
+        <Form
+          onSubmit={jest.fn()}
+          component={InvestForm}
+          investThrough={INVESTMENT_OPTIONS.METAMASK}
+          updateInvestThrough={jest.fn()}
+          web3Available={true}
+        />
+      </Provider>
+    )
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it(`should update tokensToInvest in investStore`, () => {
+    const investStore = new InvestStore()
+    const tokenStore = new TokenStore()
+    const value = 55
+
+    const wrapper = mount(
+      <Provider investStore={investStore} tokenStore={tokenStore}>
+        <Form
+          onSubmit={jest.fn()}
+          component={InvestForm}
+          investThrough={INVESTMENT_OPTIONS.METAMASK}
+          updateInvestThrough={jest.fn()}
+          web3Available={true}
+        />
+      </Provider>
+    )
+
+    expect(investStore.tokensToInvest).toBeUndefined()
+
+    wrapper.find('input').simulate('change', { target: { value } })
+
+    expect(investStore.tokensToInvest).toBe(value)
+  })
+
+  it(`should call onSubmit`, () => {
+    const investStore = new InvestStore()
+    const tokenStore = new TokenStore()
+    const onSubmit = jest.fn()
+
+    tokenStore.setProperty('decimals', 18)
+
+    const wrapper = mount(
+      <Provider investStore={investStore} tokenStore={tokenStore}>
+        <Form
+          onSubmit={onSubmit}
+          component={InvestForm}
+          investThrough={INVESTMENT_OPTIONS.METAMASK}
+          updateInvestThrough={jest.fn()}
+          web3Available={true}
+        />
+      </Provider>
+    )
+
+    wrapper.find('input').simulate('change', { target: { value: 55 } })
+    wrapper.find('.button_fill').simulate('click')
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it(`should set investThrough to QR`, () => {
+    const investStore = new InvestStore()
+    const tokenStore = new TokenStore()
+    const updateInvestThrough = jest.fn()
+
+    const wrapper = mount(
+      <Provider investStore={investStore} tokenStore={tokenStore}>
+        <Form
+          onSubmit={jest.fn()}
+          component={InvestForm}
+          investThrough={INVESTMENT_OPTIONS.METAMASK}
+          updateInvestThrough={updateInvestThrough}
+          web3Available={true}
+        />
+      </Provider>
+    )
+
+    wrapper.find('select').simulate('change', { target: { value: INVESTMENT_OPTIONS.QR } })
+
+    expect(updateInvestThrough).toHaveBeenCalledTimes(1)
+    expect(updateInvestThrough).toHaveBeenCalledWith(INVESTMENT_OPTIONS.QR)
+  })
+})

--- a/src/components/invest/__snapshots__/InvestForm.spec.js.snap
+++ b/src/components/invest/__snapshots__/InvestForm.spec.js.snap
@@ -1,0 +1,301 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InvestForm should render InvestForm component 1`] = `
+<inject-_class-with-investStore-tokenStore
+  __versions={
+    Object {
+      "final-form": "4.2.0",
+      "react-final-form": "3.1.4",
+    }
+  }
+  batch={[Function]}
+  blur={[Function]}
+  change={[Function]}
+  dirty={false}
+  dirtySinceLastSubmit={false}
+  errors={Object {}}
+  focus={[Function]}
+  handleSubmit={[Function]}
+  initialize={[Function]}
+  invalid={false}
+  investThrough="metamask"
+  mutators={Object {}}
+  pristine={true}
+  reset={[Function]}
+  submitFailed={false}
+  submitSucceeded={false}
+  submitting={false}
+  touched={Object {}}
+  updateInvestThrough={[Function]}
+  valid={true}
+  validating={false}
+  values={Object {}}
+  visited={Object {}}
+  web3Available={true}
+/>
+`;
+
+exports[`InvestForm should render InvestForm component and its children 1`] = `
+<Provider
+  investStore={InvestStore {}}
+  tokenStore={
+    TokenStore {
+      "decimals": undefined,
+      "name": undefined,
+      "reservedTokens": Array [],
+      "reservedTokensInput": Object {},
+      "supply": 0,
+      "ticker": undefined,
+      "validToken": Object {
+        "decimals": "EMPTY",
+        "name": "EMPTY",
+        "ticker": "EMPTY",
+      },
+    }
+  }
+>
+  <ReactFinalForm(4.2.0)(3.1.4)
+    component={[Function]}
+    investThrough="metamask"
+    onSubmit={[Function]}
+    updateInvestThrough={[Function]}
+    web3Available={true}
+  >
+    <inject-_class-with-investStore-tokenStore
+      __versions={
+        Object {
+          "final-form": "4.2.0",
+          "react-final-form": "3.1.4",
+        }
+      }
+      batch={[Function]}
+      blur={[Function]}
+      change={[Function]}
+      dirty={false}
+      dirtySinceLastSubmit={false}
+      errors={Object {}}
+      focus={[Function]}
+      handleSubmit={[Function]}
+      initialize={[Function]}
+      invalid={false}
+      investThrough="metamask"
+      mutators={Object {}}
+      pristine={true}
+      reset={[Function]}
+      submitFailed={false}
+      submitSucceeded={false}
+      submitting={false}
+      touched={Object {}}
+      updateInvestThrough={[Function]}
+      valid={true}
+      validating={false}
+      values={Object {}}
+      visited={Object {}}
+      web3Available={true}
+    >
+      <_class
+        __versions={
+          Object {
+            "final-form": "4.2.0",
+            "react-final-form": "3.1.4",
+          }
+        }
+        batch={[Function]}
+        blur={[Function]}
+        change={[Function]}
+        dirty={false}
+        dirtySinceLastSubmit={false}
+        errors={Object {}}
+        focus={[Function]}
+        handleSubmit={[Function]}
+        initialize={[Function]}
+        invalid={false}
+        investStore={InvestStore {}}
+        investThrough="metamask"
+        mutators={Object {}}
+        pristine={true}
+        reset={[Function]}
+        submitFailed={false}
+        submitSucceeded={false}
+        submitting={false}
+        tokenStore={
+          TokenStore {
+            "decimals": undefined,
+            "name": undefined,
+            "reservedTokens": Array [],
+            "reservedTokensInput": Object {},
+            "supply": 0,
+            "ticker": undefined,
+            "validToken": Object {
+              "decimals": "EMPTY",
+              "name": "EMPTY",
+              "ticker": "EMPTY",
+            },
+          }
+        }
+        touched={Object {}}
+        updateInvestThrough={[Function]}
+        valid={true}
+        validating={false}
+        values={Object {}}
+        visited={Object {}}
+        web3Available={true}
+      >
+        <form
+          className="invest-form"
+          onSubmit={[Function]}
+        >
+          <label
+            className="invest-form-label"
+          >
+            Choose amount to invest
+          </label>
+          <div
+            className="invest-form-input-container"
+          >
+            <Field
+              component={[Function]}
+              format={[Function]}
+              inputClassName="invest-form-input"
+              name="invest"
+              parse={[Function]}
+              placeholder="0"
+              validate={[Function]}
+            >
+              <InputField2
+                input={
+                  Object {
+                    "name": "invest",
+                    "onBlur": [Function],
+                    "onChange": [Function],
+                    "onFocus": [Function],
+                    "value": "",
+                  }
+                }
+                inputClassName="invest-form-input"
+                meta={
+                  Object {
+                    "active": false,
+                    "data": Object {},
+                    "dirty": false,
+                    "dirtySinceLastSubmit": false,
+                    "error": "This field is required",
+                    "initial": undefined,
+                    "invalid": true,
+                    "length": undefined,
+                    "pristine": true,
+                    "submitError": undefined,
+                    "submitFailed": false,
+                    "submitSucceeded": false,
+                    "touched": false,
+                    "valid": false,
+                    "visited": false,
+                  }
+                }
+                placeholder="0"
+              >
+                <div>
+                  <label
+                    className="label"
+                    htmlFor="invest"
+                  />
+                  <input
+                    autoComplete="off"
+                    className="invest-form-input"
+                    id="invest"
+                    name="invest"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="0"
+                    value=""
+                  />
+                  <p
+                    className="description"
+                  />
+                  <Error
+                    name="invest"
+                  >
+                    <Field
+                      format={[Function]}
+                      name="invest"
+                      parse={[Function]}
+                      render={[Function]}
+                      subscription={
+                        Object {
+                          "error": true,
+                          "pristine": true,
+                          "touched": true,
+                        }
+                      }
+                    >
+                      <span>
+                        <p
+                          className="error"
+                          key="0"
+                          style={
+                            Object {
+                              "color": "red",
+                              "fontSize": "12px",
+                              "fontWeight": "bold",
+                              "height": "20px",
+                              "width": "100%",
+                            }
+                          }
+                        />
+                      </span>
+                    </Field>
+                  </Error>
+                </div>
+              </InputField2>
+            </Field>
+            <FormSpy
+              onChange={[Function]}
+              subscription={
+                Object {
+                  "values": true,
+                }
+              }
+            />
+            <div
+              className="invest-form-label"
+            >
+              TOKENS
+            </div>
+          </div>
+          <div
+            className="invest-through-container"
+          >
+            <select
+              className="invest-through"
+              onChange={[Function]}
+              value="metamask"
+            >
+              <option
+                disabled={false}
+                value="metamask"
+              />
+              <option
+                value="qr"
+              >
+                QR
+              </option>
+            </select>
+            <a
+              className="button button_fill button_disabled"
+              onClick={[Function]}
+            >
+              Contribute
+            </a>
+          </div>
+          <p
+            className="description"
+          >
+            Think twice before contributing to Crowdsales. Tokens will be deposited on a wallet you used to buy tokens.
+          </p>
+        </form>
+      </_class>
+    </inject-_class-with-investStore-tokenStore>
+  </ReactFinalForm(4.2.0)(3.1.4)>
+</Provider>
+`;

--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -336,8 +336,7 @@ export class Invest extends React.Component {
     const tokenAddress = getContractStoreProperty('token', 'addr')
 
     //balance
-    const investorBalanceTiers = tokenAmountOf ? (tokenAmountOf / 10 ** tokenDecimals).toString() : '0'
-    const investorBalance = investorBalanceTiers
+    const investorBalance = tokenAmountOf ? toBigNumber(tokenAmountOf).div(`1e${tokenDecimals}`).toFixed() : '0'
 
     //total supply
     const totalSupply = maxCapBeforeDecimals.toFixed()

--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -268,7 +268,7 @@ export class Invest extends React.Component {
 
     const opts = {
       from: accounts[0],
-      value: weiToSend,
+      value: weiToSend.integerValue(BigNumber.ROUND_CEIL),
       gasPrice: generalStore.gasPrice
     }
     console.log(opts)


### PR DESCRIPTION
Closes #785 & #797 

This PR:
- Implements `final-form` in the invest page and its validations for the input field
- Displays `balance` with all its decimals when valid

**note**: when `rate` isn't a divisor of `1e18`, the conversion to/from eth may lead to not precise values, for instance:
- using a rate of `151`,
- if user buys `2.1` tokens,
- balance will display: `2.100000000000000135` tokens
