### PR TITLE
(Fix) Summary files fixes

### DIFF
--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -53,6 +53,7 @@ export class stepFour extends React.Component {
       deploymentStore.setDeploymentStep(0)
       deploymentStore.setDeployerAccount(context.selectedAccount)
     }
+
   }
 
   static contextTypes = {
@@ -81,7 +82,7 @@ export class stepFour extends React.Component {
   deployCrowdsale = () => {
     const { deploymentStore } = this.props
     const { web3 } = this.context
-    const firstRun = deploymentStore.deploymentStep === null
+    const firstRun = deploymentStore.deploymentStep === 0
 
     if (firstRun) {
       setupContractDeployment(web3)
@@ -203,6 +204,7 @@ export class stepFour extends React.Component {
           const solFilename = `${orderNumber(prefix++)}_${name}${suffix}`
           const txtFilename = `${orderNumber(prefix++)}_${name}${suffix}`
           const tierNumber = FINALIZE_AGENT === key ? tiersCount - 1 : tier
+
           const commonHeader = FILE_CONTENTS.common.map(content => this.handleContentByParent(content, tierNumber))
 
           zip.file(

--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -53,7 +53,6 @@ export class stepFour extends React.Component {
       deploymentStore.setDeploymentStep(0)
       deploymentStore.setDeployerAccount(context.selectedAccount)
     }
-
   }
 
   static contextTypes = {
@@ -204,7 +203,6 @@ export class stepFour extends React.Component {
           const solFilename = `${orderNumber(prefix++)}_${name}${suffix}`
           const txtFilename = `${orderNumber(prefix++)}_${name}${suffix}`
           const tierNumber = FINALIZE_AGENT === key ? tiersCount - 1 : tier
-
           const commonHeader = FILE_CONTENTS.common.map(content => this.handleContentByParent(content, tierNumber))
 
           zip.file(

--- a/src/stores/ContractStore.js
+++ b/src/stores/ContractStore.js
@@ -6,10 +6,8 @@ class ContractStore {
   @observable token;
   @observable crowdsale;
   @observable pricingStrategy;
-  @observable multisig;
   @observable nullFinalizeAgent;
   @observable finalizeAgent;
-  @observable tokenTransferProxy;
   @observable safeMathLib;
   @observable registry;
 

--- a/src/stores/utils.js
+++ b/src/stores/utils.js
@@ -57,7 +57,6 @@ export const getconstructorParams = (abiConstructor, vals, crowdsaleNum, isCrowd
           params.vals.push(tierStore.tiers[crowdsaleNum].rate);
           break;
         case "_multisigWallet":
-          //params.vals.push(contractStore.multisig.addr);
           params.vals.push(tierStore.tiers[0].walletAddress);
           break;
         case "_pricingStrategy":

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -361,7 +361,7 @@ export const FILE_CONTENTS = {
   }
 }
 
-export const DOWNLOAD_NAME = 'icowizard'
+export const DOWNLOAD_NAME = 'tokenwizard'
 export const DOWNLOAD_TYPE = {
   text: 'text/plain',
   blob: 'blob'


### PR DESCRIPTION
**Problem**: users complain that they don't have `FlatPricingExt` source code and summary file. Also, summary file for `CrowdsaleTokenExt` contract doesn't include ABI encoded parameters.
**Solution**:  `deploymentStore.deploymentStep` never reaches `null` because it is set to `0` in the constructor. Thus, it should compare with `0` in `deployCrowdsale` function.

Also,
- obsolete `multisig` contract is removed from ContractStore
- obsolete `tokenTransferProxy` contract is removed from ContractStore
- archive prefix is renamed from `icowizard` to `tokenwizard`