### PR TITLE
(Fix) handlerForFile function debug

### DIFF
--- a/src/components/stepFour/utils.js
+++ b/src/components/stepFour/utils.js
@@ -674,7 +674,20 @@ export const handlerForFile = (content, type) => {
     suffix = ` (GMT ${operator} ${Math.abs(timezoneOffset)})`
   }
 
-  return `${content.value}${type[content.field]}${suffix}`
+  console.log("content:", content)
+  console.log("type:", type)
+
+  if (content && type) {
+    return `${content.value}${type[content.field]}${suffix}`
+  } else {
+    if (!content) {
+      console.log("WARNING!: content is undefined")
+    }
+    if (!type) {
+      console.log("WARNING!: type is undefined")
+    }
+    return ''
+  }
 }
 
 export const handleConstantForFile = content => {


### PR DESCRIPTION
**Problem**: there are a few appeals like this https://forum.poa.network/t/stuck-at-token-wizard-step-4/1142/4 with the error: `Cannot read property 'rate' of undefined` on downloading of summary files. This error blocks downloading. Sometimes it is caused by increasing gas price in MetaMask (and [we don't recommend to do this](https://github.com/poanetwork/token-wizard/wiki/FAQ#13-i-confirmed-transaction-in-metamask-and-after-some-time-of-waiting-i-see-the-message-in-metamask-taking-too-long-retry-with-a-higher-gas-price-here-should-i-increase-gas)) but sometimes - by other reasons (we don't know those exactly)
**Solution**: As we can't repeat the same bug, I have added the check that both `content` and `type` are not empty (it will unlock downloading of the summary files) and additional logging is added for research if the problem will appear again.