### PR TITLE
(Fix) show crowdsale page if no Metamask

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,7 @@ class App extends Component {
           <Header/>
 
           <Switch>
+            <Route exact path="/crowdsale" component={Crowdsale}/>
             <Route exact path="/invest" component={Invest}/>
 
             <Route>
@@ -45,7 +46,6 @@ class App extends Component {
                     ) : (
                       <Switch>
                         <Route exact path="/" component={crowdsaleAddr ? Crowdsale : Home}/>
-                        <Route exact path="/crowdsale" component={Crowdsale}/>
                         <Route exact path="/manage/:crowdsaleAddress" component={Manage}/>
                         <Route path="/1" component={stepOne}/>
                         <Route path="/2" component={stepTwo}/>

--- a/src/components/invest/index.js
+++ b/src/components/invest/index.js
@@ -17,6 +17,7 @@ import {
   invalidCrowdsaleAddrAlert,
   investmentDisabledAlertInTime, noGasPriceAvailable,
   noMetaMaskAlert,
+  MetaMaskIsLockedAlert,
   successfulInvestmentAlert
 } from '../../utils/alerts'
 import { Loader } from '../Common/Loader'
@@ -217,7 +218,7 @@ export class Invest extends React.Component {
 
     if (web3.eth.accounts.length === 0) {
       this.setState({ loading: false })
-      return noMetaMaskAlert()
+      return MetaMaskIsLockedAlert()
     }
 
     this.investToTokensForWhitelistedCrowdsale()

--- a/src/stores/Web3Store.js
+++ b/src/stores/Web3Store.js
@@ -16,7 +16,9 @@ class Web3Store {
         this.web3 = web3
         web3.eth.getAccounts().then((accounts) => {
           this.accounts = accounts
-          this.curAddress = accounts[0]
+          if (accounts.length > 0) {
+            this.curAddress = accounts[0]
+          }
         })
       }
     })
@@ -27,7 +29,8 @@ class Web3Store {
   }
 
   getWeb3 = cb => {
-    const networkID = CrowdsaleConfig.networkID ? CrowdsaleConfig.networkID : getQueryVariable('networkID')
+    let networkID = CrowdsaleConfig.networkID ? CrowdsaleConfig.networkID : getQueryVariable('networkID')
+    networkID = Number(networkID)
     var web3 = window.web3;
     if (typeof web3 === 'undefined') {
       // no web3, use fallback
@@ -57,7 +60,8 @@ class Web3Store {
             infuraLink = this.getInfuraLink(CHAINS.MAINNET)
             break
         }
-        web3 = new Web3(new Web3.providers.HttpProvider(infuraLink));
+        let httpProvider = new Web3.providers.HttpProvider(infuraLink)
+        web3 = new Web3(httpProvider)
       }
 
       cb(web3, false);

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -10,6 +10,14 @@ export function noMetaMaskAlert() {
   });
 }
 
+export function MetaMaskIsLockedAlert() {
+  sweetAlert2({
+    title: "Warning",
+    html: "You signed out from Metamask. Open Metamask extension and sign in.",
+    type: "warning"
+  });
+}
+
 export function noContractDataAlert() {
   sweetAlert2({
     title: "Warning",
@@ -66,14 +74,6 @@ export function incorrectNetworkAlert(correctNetworkName, incorrectNetworkName) 
   sweetAlert2({
     title: "Warning",
     html: "Crowdsale contract is from <b>" + correctNetworkName + " network</b>. But you are connected to <b>" + incorrectNetworkName + " network</b>. Please, change connection in MetaMask plugin.",
-    type: "warning"
-  });
-}
-
-export function noDeploymentOnMainnetAlert() {
-  sweetAlert2({
-    title: "Warning",
-    html: "Wizard is under maintenance on Ethereum Mainnet. Please come back later or use Kovan/Rinkeby/POA. Follow <a href='https://twitter.com/poanetwork'>https://twitter.com/poanetwork</a> for status.",
     type: "warning"
   });
 }

--- a/src/utils/blockchainHelpers.js
+++ b/src/utils/blockchainHelpers.js
@@ -1,4 +1,4 @@
-import { incorrectNetworkAlert, noMetaMaskAlert, invalidNetworkIDAlert } from './alerts'
+import { incorrectNetworkAlert, noMetaMaskAlert, MetaMaskIsLockedAlert, invalidNetworkIDAlert } from './alerts'
 import { CHAINS, MAX_GAS_PRICE } from './constants'
 import { crowdsaleStore, generalStore, web3Store } from '../stores'
 import { fetchFile } from './utils'
@@ -24,11 +24,21 @@ export function checkWeb3 () {
 
 const checkMetaMask = () => {
   const { web3 } = web3Store
+  console.log(web3.currentProvider)
 
-  web3.eth.getAccounts()
-    .then(accounts => {
-      if (accounts.length === 0) return noMetaMaskAlert()
-    })
+  if (!web3.currentProvider) {
+    return noMetaMaskAlert()
+  }
+
+  if (web3.currentProvider.isMetaMask) {
+    web3.eth.getAccounts()
+      .then(accounts => {
+        if (accounts.length === 0) return MetaMaskIsLockedAlert()
+      })
+      .catch((err) => {
+        return MetaMaskIsLockedAlert()
+      })
+  }
 }
 
 export function checkNetWorkByID (_networkIdFromGET) {


### PR DESCRIPTION
Closes #866

**Problem**: crowdsale page is hidden if Metamask is not present

**Solution**: Since we introduced the connection to Infura for crowdsale and invest page here: https://github.com/poanetwork/token-wizard/pull/826 we should not hide crowdsale page anymore.

Also, minor fixes:
- `MetaMaskIsLockedAlert()` is introduced - if Metamask is installed but is locked
- `noDeploymentOnMainnetAlert()` is removed. It is duplicate of `mainnetIsOnMaintenance` alert