### PR TITLE
(Fix) Persist crowdsale deployment status

### DIFF
--- a/src/stores/ContractStore.js
+++ b/src/stores/ContractStore.js
@@ -12,6 +12,15 @@ class ContractStore {
   @observable initCrowdsaleDutchAuction;
   @observable crowdsaleConsoleDutchAuction;
   @observable crowdsaleBuyTokensDutchAuction;
+  @observable crowdsale;
+  @observable appConsole;
+  @observable versionConsole;
+  @observable implementationConsole;
+  @observable tokenConsoleMintedCapped;
+  @observable tokenTransfer;
+  @observable tokenTransferFrom;
+  @observable tokenApprove;
+  @observable tokenConsoleDutchAuction;
 
   constructor() {
     autosave(this, 'ContractStore')


### PR DESCRIPTION
Closes #828

As a rule, every new _observable_ added to any store must be declared in the store itself.