### PR TITLE
(Fix) Update events' interfaces

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,8 +1,8 @@
 export const REACT_PREFIX = 'REACT_APP_'
 
 export const EXCEPTIONS = {
-  storageException: "StorageException(address,bytes32,address,uint256)",
-  applicationException: "ApplicationException(address, bytes32, bytes32)"
+  storageException: "StorageException(bytes32,string)",
+  applicationException: "ApplicationException(address, bytes32, bytes)"
 }
 
 export const CROWDSALE_STRATEGIES = {


### PR DESCRIPTION
Closes #950

Interfaces of events have been changed since Auth-os v.1.0.1:

`ApplicationException`:
https://github.com/auth-os/applications/blob/4d8c7149d031944d8b85de873b7f6875e9c49d55/TokenWizard/crowdsale/MintedCappedCrowdsale/test/auth_os/core/AbstractStorage.sol#L51

`StorageException`
https://github.com/auth-os/core/blob/79165be925b5aaebca18508f0118892da694c67a/contracts/core/ScriptExec.sol#L37