### PR TITLE
(Fix) Min cap validate with supply

### DIFF
--- a/src/components/Common/DutchAuctionBlock.js
+++ b/src/components/Common/DutchAuctionBlock.js
@@ -188,6 +188,7 @@ export const DutchAuctionBlock = inject('tierStore', 'tokenStore')(observer(({ t
               name={`${name}.minCap`}
               errorStyle={inputErrorStyle}
               decimals={props.decimals}
+              supply={tierStore ? tierStore.tiers[index].supply : 0}
               disabled={tierStore ? tierStore.tiers[index].whitelistEnabled === 'yes' : true}
               side="left"
             />

--- a/src/components/Common/DutchAuctionBlock.js
+++ b/src/components/Common/DutchAuctionBlock.js
@@ -188,7 +188,7 @@ export const DutchAuctionBlock = inject('tierStore', 'tokenStore')(observer(({ t
               name={`${name}.minCap`}
               errorStyle={inputErrorStyle}
               decimals={props.decimals}
-              supply={tierStore ? tierStore.tiers[index].supply : 0}
+              index={index}
               disabled={tierStore ? tierStore.tiers[index].whitelistEnabled === 'yes' : true}
               side="left"
             />

--- a/src/components/Common/DutchAuctionBlock.js
+++ b/src/components/Common/DutchAuctionBlock.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Field } from 'react-final-form'
 import { InputField2 } from './InputField2'
 import { WhitelistInputBlock } from './WhitelistInputBlock'
-import { GlobalMinCap } from './GlobalMinCap'
+import { MinCap } from './MinCap'
 import {
   composeValidators,
   isDateInFuture,
@@ -184,7 +184,7 @@ export const DutchAuctionBlock = inject('tierStore', 'tokenStore')(observer(({ t
             </div>
           </div>
           <div className="input-block-container">
-            <GlobalMinCap
+            <MinCap
               name={`${name}.minCap`}
               errorStyle={inputErrorStyle}
               decimals={props.decimals}

--- a/src/components/Common/MinCap.js
+++ b/src/components/Common/MinCap.js
@@ -4,7 +4,7 @@ import { InputField2 } from './InputField2'
 import { composeValidators, isDecimalPlacesNotGreaterThan, isNonNegative } from '../../utils/validations'
 import { DESCRIPTION, TEXT_FIELDS } from '../../utils/constants'
 
-export const GlobalMinCap = ({ ...props }) => (
+export const MinCap = ({ ...props }) => (
   <Field
     component={InputField2}
     validate={composeValidators(

--- a/src/components/Common/MinCap.js
+++ b/src/components/Common/MinCap.js
@@ -1,27 +1,14 @@
 import React from 'react'
 import { Field } from 'react-final-form'
 import { InputField2 } from './InputField2'
-import {
-  composeValidators,
-  isDecimalPlacesNotGreaterThan,
-  isLessOrEqualThan,
-  isNonNegative
-} from '../../utils/validations'
+import { validateTierMinCap } from '../../utils/validations'
 import { DESCRIPTION, TEXT_FIELDS } from '../../utils/constants'
 
-export const MinCap = ({ ...props }) => (
+export const MinCap = ({ index, decimals, ...props }) => (
   <Field
     component={InputField2}
-    validate={(value) => {
-      const errors = composeValidators(
-        isNonNegative(),
-        isDecimalPlacesNotGreaterThan(`Decimals should not exceed ${props.decimals} places`)(props.decimals),
-        isLessOrEqualThan(`Should be less or equal than tier's supply (${props.supply})`)(props.supply)
-      )(value)
-
-      if (errors) return errors.shift()
-    }}
-    type="number"
+    validate={props.disabled ? undefined : validateTierMinCap(decimals)(index)}
+    type="text"
     label={props.label || TEXT_FIELDS.MIN_CAP}
     description={DESCRIPTION.MIN_CAP}
     {...props}

--- a/src/components/Common/MinCap.js
+++ b/src/components/Common/MinCap.js
@@ -1,16 +1,26 @@
 import React from 'react'
 import { Field } from 'react-final-form'
 import { InputField2 } from './InputField2'
-import { composeValidators, isDecimalPlacesNotGreaterThan, isNonNegative } from '../../utils/validations'
+import {
+  composeValidators,
+  isDecimalPlacesNotGreaterThan,
+  isLessOrEqualThan,
+  isNonNegative
+} from '../../utils/validations'
 import { DESCRIPTION, TEXT_FIELDS } from '../../utils/constants'
 
 export const MinCap = ({ ...props }) => (
   <Field
     component={InputField2}
-    validate={composeValidators(
-      isNonNegative(),
-      isDecimalPlacesNotGreaterThan()(props.decimals)
-    )}
+    validate={(value) => {
+      const errors = composeValidators(
+        isNonNegative(),
+        isDecimalPlacesNotGreaterThan(`Decimals should not exceed ${props.decimals} places`)(props.decimals),
+        isLessOrEqualThan(`Should be less or equal than tier's supply (${props.supply})`)(props.supply)
+      )(value)
+
+      if (errors) return errors.shift()
+    }}
     type="number"
     label={props.label || TEXT_FIELDS.MIN_CAP}
     description={DESCRIPTION.MIN_CAP}

--- a/src/components/Common/TierBlock.js
+++ b/src/components/Common/TierBlock.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Field } from 'react-final-form'
-import { OnChange } from 'react-final-form-listeners'
 import { InputField2 } from './InputField2'
 import { WhitelistInputBlock } from './WhitelistInputBlock'
 import {

--- a/src/components/Common/TierBlock.js
+++ b/src/components/Common/TierBlock.js
@@ -13,7 +13,7 @@ import { CrowdsaleStartTime } from './CrowdsaleStartTime'
 import { CrowdsaleEndTime } from './CrowdsaleEndTime'
 import { CrowdsaleRate } from './CrowdsaleRate'
 import { Supply } from './Supply'
-import { GlobalMinCap } from './GlobalMinCap'
+import { MinCap } from './MinCap'
 
 const { ALLOW_MODIFYING, CROWDSALE_SETUP_NAME, ENABLE_WHITELISTING } = TEXT_FIELDS
 
@@ -142,7 +142,7 @@ export const TierBlock = ({ fields, ...props }) => {
               />
             </div>
             <div className="input-block-container">
-              <GlobalMinCap
+              <MinCap
                 name={`${name}.minCap`}
                 errorStyle={inputErrorStyle}
                 decimals={props.decimals}

--- a/src/components/Common/TierBlock.js
+++ b/src/components/Common/TierBlock.js
@@ -150,22 +150,6 @@ export const TierBlock = ({ fields, ...props }) => {
                 disabled={props.tierStore ? props.tierStore.tiers[index].whitelistEnabled === 'yes' : true}
                 side="left"
               />
-              {
-                /*
-                  * TODO: REVIEW. I'm not sure about this approach.
-                  * But it worked for me to keep the error messages properly updated for the minCap field.
-                  */
-              }
-              <Field name={`${name}.minCap`} subscription={{}}>
-                {({ input: { onChange } }) => (
-                  <OnChange name={`${name}.supply`}>
-                    {() => {
-                      onChange(0)
-                      onChange(props.tierStore.tiers[index].minCap)
-                    }}
-                  </OnChange>
-                )}
-              </Field>
             </div>
           </div>
           {

--- a/src/components/Common/TierBlock.js
+++ b/src/components/Common/TierBlock.js
@@ -146,6 +146,7 @@ export const TierBlock = ({ fields, ...props }) => {
                 name={`${name}.minCap`}
                 errorStyle={inputErrorStyle}
                 decimals={props.decimals}
+                supply={props.tierStore.tiers[index].supply}
                 tierStore={props.tierStore}
                 disabled={props.tierStore ? props.tierStore.tiers[index].whitelistEnabled === 'yes' : true}
                 side="left"

--- a/src/components/Common/TierBlock.js
+++ b/src/components/Common/TierBlock.js
@@ -145,8 +145,7 @@ export const TierBlock = ({ fields, ...props }) => {
                 name={`${name}.minCap`}
                 errorStyle={inputErrorStyle}
                 decimals={props.decimals}
-                supply={props.tierStore.tiers[index].supply}
-                tierStore={props.tierStore}
+                index={index}
                 disabled={props.tierStore ? props.tierStore.tiers[index].whitelistEnabled === 'yes' : true}
                 side="left"
               />

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -9,7 +9,6 @@ import { inject, observer } from "mobx-react";
 import { Loader } from '../Common/Loader'
 import { noGasPriceAvailable, warningOnMainnetAlert } from '../../utils/alerts'
 import { getStep3Component } from './utils'
-import { isLessOrEqualThan } from '../../utils/validations'
 import createDecorator from 'final-form-calculate'
 
 const { CROWDSALE_SETUP } = NAVIGATION_STEPS;

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -130,20 +130,6 @@ export class stepThree extends React.Component {
           tierStore={tierStore}
           generalStore={generalStore}
           crowdsaleStore={crowdsaleStore}
-          validate={(values) => {
-            const errors = {}
-            const maxSupply = tierStore.maxSupply
-            const minCapFromValues = values.tiers.reduce((sum, tier) => {
-              return sum + Number(tier.minCap)
-            }, 0)
-            const minCap = maxSupply !== 0
-              ? isLessOrEqualThan('Should be less or equal than the supply of some tier')(maxSupply)(minCapFromValues)
-              : undefined
-
-            if (minCap) errors.minCap = minCap
-
-            return errors
-          }}
         />
         <Loader show={this.state.loading}/>
       </section>

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -149,3 +149,13 @@ export const validateTierEndDate  = (index) => (value, values) => {
 
   return composeValidators(...listOfValidations)(value)
 }
+
+export const validateTierMinCap = (decimals) => (index) => (value, values) => {
+  const listOfValidations = [
+    isNonNegative(),
+    isDecimalPlacesNotGreaterThan(`Decimals should not exceed ${decimals} places`)(decimals),
+    isLessOrEqualThan(`Should be less or equal than tier's supply (${values.tiers[index].supply})`)(values.tiers[index].supply)
+  ]
+
+  return composeValidators(...listOfValidations)(value)
+}

--- a/src/utils/validations.spec.js
+++ b/src/utils/validations.spec.js
@@ -16,6 +16,7 @@ import {
   isPositive,
   isRequired,
   validateTierEndDate,
+  validateTierMinCap,
   validateTierStartDate,
   validateWhitelistMax,
   validateWhitelistMin,
@@ -724,4 +725,70 @@ describe('validateTierEndDate', () => {
 
     expect(validationResult).toEqual(["Should be same or previous than next tier's Start Time"])
   })*/
+})
+
+describe('validateTierMinCap', () => {
+  it(`should fail if minCap is greater than supply`, () => {
+    const values = {
+      tiers: [
+        {
+          supply: '150'
+        }
+      ]
+    }
+    const decimals = 0
+    const index = 0
+    const minCap = 300
+    const validationResult = validateTierMinCap(decimals)(index)(minCap, values)
+
+    expect(validationResult).toEqual([`Should be less or equal than tier's supply (${values.tiers[index].supply})`])
+  })
+
+  it(`should pass if minCap is less than supply`, () => {
+    const values = {
+      tiers: [
+        {
+          supply: '150'
+        }
+      ]
+    }
+    const decimals = 0
+    const index = 0
+    const minCap = 100
+    const validationResult = validateTierMinCap(decimals)(index)(minCap, values)
+
+    expect(validationResult).toBeUndefined()
+  })
+
+  it(`should fail if minCap decimals count is greater than specified`, () => {
+    const values = {
+      tiers: [
+        {
+          supply: '150'
+        }
+      ]
+    }
+    const decimals = 5
+    const index = 0
+    const minCap = 100.123456
+    const validationResult = validateTierMinCap(decimals)(index)(minCap, values)
+
+    expect(validationResult).toEqual([`Decimals should not exceed ${decimals} places`])
+  })
+
+  it(`should fail if minCap decimals count is greater than specified`, () => {
+    const values = {
+      tiers: [
+        {
+          supply: '150'
+        }
+      ]
+    }
+    const decimals = 5
+    const index = 0
+    const minCap = 100.12345
+    const validationResult = validateTierMinCap(decimals)(index)(minCap, values)
+
+    expect(validationResult).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Closes #946

Since bug was reported, `globalMinCap` is no longer used. Now `minCap` is specified in a per-tier basis.

Anyway, this issue was used to track `minCap` validation in `StepThree`.