### PR TITLE
(Fix) Total Raised Funds expressed in scientific notation

### DIFF
--- a/src/components/crowdsale/index.js
+++ b/src/components/crowdsale/index.js
@@ -214,7 +214,7 @@ export class Crowdsale extends React.Component {
           <div className="total-funds">
             <div className="hidden">
               <div className="left">
-                <p className="total-funds-title">{`${ethRaised}`} ETH</p>
+                <p className="total-funds-title">{`${ethRaised.toFixed()}`} ETH</p>
                 <p className="total-funds-description">Total Raised Funds</p>
               </div>
               <div className="right">


### PR DESCRIPTION
Closes #815 

- Added `toFixed() ` function 
- See [bignumber docs](https://mikemcl.github.io/bignumber.js/#toFix) for more details

Image before fix:
![screenshot_20180628_204143](https://user-images.githubusercontent.com/1144028/42070300-18f50a88-7b2c-11e8-9980-fb3a704cd435.png)

Image after fix:
![screenshot_20180628_233537](https://user-images.githubusercontent.com/1144028/42070310-25779f1e-7b2c-11e8-9aec-4fcdc5c0d475.png)


