### PR TITLE
(Feature) One wallet address for the whole summary 

### DIFF
--- a/src/components/stepFour/index.js
+++ b/src/components/stepFour/index.js
@@ -304,29 +304,25 @@ export class stepFour extends React.Component {
             <div className="hidden">
               <DisplayField
                 side='left'
-                title={'Wallet address'}
-                value={tierStore.tiers[0].walletAddress}
-                description="Where the money goes after investors transactions."
-              />
-              <DisplayField
-                side='right'
                 title={'RATE'}
                 value={tier.rate ? tier.rate : 0 + ' ETH'}
                 description={DESCRIPTION.RATE}
               />
+              <DisplayField
+                side='right'
+                title={'Max cap'}
+                value={tier.supply ? tier.supply : ''}
+                description="How many tokens will be sold on this tier."
+              />
             </div>
-            <DisplayField
-              side='left'
-              title={'Max cap'}
-              value={tier.supply ? tier.supply : ''}
-              description="How many tokens will be sold on this tier."
-            />
-            <DisplayField
-              side='right'
-              title={'Allow modifying'}
-              value={tier.updatable ? tier.updatable : 'off'}
-              description={DESCRIPTION.ALLOW_MODIFYING}
-            />
+            <div className="hidden">
+              <DisplayField
+                side='left'
+                title={'Allow modifying'}
+                value={tier.updatable ? tier.updatable : 'off'}
+                description={DESCRIPTION.ALLOW_MODIFYING}
+              />
+            </div>
           </div>
         </div>
       )
@@ -450,12 +446,25 @@ export class stepFour extends React.Component {
             </p>
           </div>
           <div className="hidden">
-            <div className="item">
-              <div className="publish-title-container">
-                <p className="publish-title" data-step="1">Crowdsale Contract</p>
+            <div className="publish-title-container">
+              <p className="publish-title" data-step="1">Crowdsale Contract</p>
+            </div>
+            <div className="hidden">
+              <div className="hidden">
+                <div className="left">
+                  <div className="display-container">
+                    <p className="label">Whitelist with cap</p>
+                    <p className="description">Crowdsale Contract</p>
+                  </div>
+                </div>
+
+                <DisplayField
+                  side='right'
+                  title={'Wallet address'}
+                  value={tierStore.tiers[0].walletAddress}
+                  description="Where the money goes after investors transactions."
+                />
               </div>
-              <p className="label">Whitelist with cap</p>
-              <p className="description">Crowdsale Contract</p>
             </div>
             <div className="publish-title-container">
               <p className="publish-title" data-step="2">Token Setup</p>


### PR DESCRIPTION
Closes #817 

- Remove DisplayField block from tiers
- The wallet address was added in the block of the crowdsale contract
- The tests were run successfully

Image before
![screenshot_20180629_165619](https://user-images.githubusercontent.com/1144028/42112240-946eb84e-7bbd-11e8-998e-ef2433521b29.png)

Image after
![screenshot_20180629_165641](https://user-images.githubusercontent.com/1144028/42112249-99e7cbc6-7bbd-11e8-90ae-e9de301f5925.png)

Test executed
![screenshot_20180629_165739](https://user-images.githubusercontent.com/1144028/42112261-9fa1fbfe-7bbd-11e8-834b-630051e3bc0d.png)
