### PR TITLE
(Bug) Button "Finalize" is active after finalization 

### DIFF
--- a/src/components/contribute/index.js
+++ b/src/components/contribute/index.js
@@ -521,7 +521,7 @@ export class Contribute extends React.Component {
                 <p className="hashes-description_cp_address">
                   {crowdsaleAddressDescription}
                   <CopyToClipboard text={crowdsaleAddress}>
-                    <btn data-tip={crowdsaleAddressTooltip} className="copy" tool />
+                    <btn data-tip={crowdsaleAddressTooltip} className="copy" />
                   </CopyToClipboard>
                 </p>
               </div>

--- a/src/components/manage/index.js
+++ b/src/components/manage/index.js
@@ -415,7 +415,7 @@ export class Manage extends Component {
 
   setCrowdsaleInfo = async () => {
     const { contractStore, crowdsaleStore } = this.props
-    const { execID, selected } = crowdsaleStore
+    const { execID, selected, isMintedCappedCrowdsale, isDutchAuction } = crowdsaleStore
     const { addr } = contractStore.abstractStorage
     const { initialTiersValues } = selected
 
@@ -444,8 +444,15 @@ export class Manage extends Component {
     }
     const { start_time, end_time } = await getCrowdsaleStartAndEndTimes(...params).call()
     let crowdsaleInfo = await getCrowdsaleInfo(...params).call()
-    if (crowdsaleInfo && crowdsaleInfo.hasOwnProperty('is_finalized')) {
-      crowdsaleInfo.is_finalized = crowdsaleInfo[4]
+
+    if (isMintedCappedCrowdsale) {
+      if (crowdsaleInfo && !crowdsaleInfo.hasOwnProperty('is_finalized')) {
+        crowdsaleInfo.is_finalized = crowdsaleInfo[3]
+      }
+    } else if (isDutchAuction) {
+      if (crowdsaleInfo && !crowdsaleInfo.hasOwnProperty('is_finalized')) {
+        crowdsaleInfo.is_finalized = crowdsaleInfo[4]
+      }
     }
     const { is_finalized } = crowdsaleInfo
 
@@ -491,12 +498,11 @@ export class Manage extends Component {
         _isCrowdsaleFull.is_crowdsale_full = _isCrowdsaleFull[0]
       }
       const { is_crowdsale_full } = _isCrowdsaleFull
+      const { crowdsaleHasEnded } = this.state
 
       if (is_finalized) {
         this.setState({ canFinalize: false })
       } else {
-        const { crowdsaleHasEnded } = this.state
-
         this.setState({
           canFinalize: crowdsaleHasEnded || is_crowdsale_full
         })
@@ -681,7 +687,7 @@ export class Manage extends Component {
     return (
       <section className="manage">
         <FinalizeCrowdsaleStep
-          disabled={!ownerCurrentUser || crowdsaleIsFinalized || !canFinalize}
+          disabled={!ownerCurrentUser || crowdsaleIsFinalized || !canFinalize || crowdsaleHasEnded}
           handleClick={this.finalizeCrowdsale}
         />
 

--- a/src/components/manage/index.js
+++ b/src/components/manage/index.js
@@ -687,7 +687,7 @@ export class Manage extends Component {
     return (
       <section className="manage">
         <FinalizeCrowdsaleStep
-          disabled={!ownerCurrentUser || crowdsaleIsFinalized || !canFinalize || crowdsaleHasEnded}
+          disabled={!ownerCurrentUser || crowdsaleIsFinalized || !canFinalize}
           handleClick={this.finalizeCrowdsale}
         />
 

--- a/src/components/manage/index.js
+++ b/src/components/manage/index.js
@@ -445,14 +445,10 @@ export class Manage extends Component {
     const { start_time, end_time } = await getCrowdsaleStartAndEndTimes(...params).call()
     let crowdsaleInfo = await getCrowdsaleInfo(...params).call()
 
-    if (isMintedCappedCrowdsale) {
-      if (crowdsaleInfo && !crowdsaleInfo.hasOwnProperty('is_finalized')) {
-        crowdsaleInfo.is_finalized = crowdsaleInfo[3]
-      }
-    } else if (isDutchAuction) {
-      if (crowdsaleInfo && !crowdsaleInfo.hasOwnProperty('is_finalized')) {
-        crowdsaleInfo.is_finalized = crowdsaleInfo[4]
-      }
+    if (isMintedCappedCrowdsale && crowdsaleInfo && !crowdsaleInfo.hasOwnProperty('is_finalized')) {
+      crowdsaleInfo.is_finalized = crowdsaleInfo[3]
+    } else if (isDutchAuction && crowdsaleInfo && !crowdsaleInfo.hasOwnProperty('is_finalized')) {
+      crowdsaleInfo.is_finalized = crowdsaleInfo[4]
     }
     const { is_finalized } = crowdsaleInfo
 


### PR DESCRIPTION
Closes #975 

- The field is_finalized  now takes into account whether it is a mintedcapped or dutch crowdsale
- Added variable to disable the button

See images
Crowdsale with all the tokens sold
![issue-975-contribute-enable-all-sell](https://user-images.githubusercontent.com/1144028/42232658-83ea0f90-7ec5-11e8-910a-828a80e44311.png)

Allow to finalize crowdsale before finish because all the tokens were sold
![issue-975-manage-enable-all-sell](https://user-images.githubusercontent.com/1144028/42232657-83b9310e-7ec5-11e8-84b0-97d663bf19d9.png)

Disable button after finish
![issue 998-disable-button-min-cap](https://user-images.githubusercontent.com/1144028/42232745-c0a20da2-7ec5-11e8-84c3-617bdbe93505.png)


