### PR TITLE
Fix (UI bug) there is no default value for global min cap field

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -30,7 +30,8 @@ export const defaultTier = {
   endTime: '',
   walletAddress: '',
   updatable: 'off',
-  whitelist: []
+  whitelist: [],
+  minCap: '0'
 }
 
 export const defaultTierValidations = {


### PR DESCRIPTION
Closes #996 

- Added default value for minCap constant

See image
![issue 996-default-value](https://user-images.githubusercontent.com/1144028/42284469-f9f6e5a6-7f82-11e8-8b42-3ce1aad0d9f5.png)
