### PR TITLE
 (Bug)Dutch: button `finalize` disabled if crowdsale time over but not all tokens were sold

### DIFF
--- a/src/components/manage/index.js
+++ b/src/components/manage/index.js
@@ -686,7 +686,7 @@ export class Manage extends Component {
     return (
       <section className="manage">
         <FinalizeCrowdsaleStep
-          disabled={!ownerCurrentUser || crowdsaleIsFinalized || !canFinalize || crowdsaleHasEnded}
+          disabled={!ownerCurrentUser || crowdsaleIsFinalized || !canFinalize}
           handleClick={this.finalizeCrowdsale}
         />
 


### PR DESCRIPTION
Closes #1016 

- Remove property from disable 

Note: 
There was a problem between the [PR #1007](https://github.com/poanetwork/token-wizard/pull/1007) and the [PR #1008](https://github.com/poanetwork/token-wizard/pull/1008) at the moment of merge, and the commit that solved this problem was lost. Now we incorporate it again.