### PR TITLE
(Refactor) Speed up build in travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
   - TEST_SUITE=e2eDutchWhitelist
   - TEST_SUITE=e2eDutchMincap
   - TEST_SUITE=reactComponentTests
+  - TEST_SUITE=contractsMinted
+  - TEST_SUITE=contractsDutch
 
 install:
 
@@ -38,7 +40,8 @@ script:
   - if [ $TEST_SUITE == 'e2eDutchUI' ]; then npm run e2eDutchUI; fi
   - if [ $TEST_SUITE == 'e2eDutchWhitelist' ]; then npm run e2eDutchWhitelist; fi
   - if [ $TEST_SUITE == 'e2eDutchMincap' ]; then npm run e2eDutchMincap; fi
-  - if [ $TEST_SUITE == 'reactComponentTests' ]; then  npm run lint && npm run coveralls; fi
+  - if [ $TEST_SUITE == 'contractsMinted' ]; then  npm run testContractsMintedCappedCrowdsale; fi
+  - if [ $TEST_SUITE == 'contractsDutch' ]; then  npm run testContractsDutchAuction; fi
 
 after_script:
   - sudo kill `sudo lsof -t -i:8545`

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 language: node_js
 node_js:
   - "8"
-env:
-  - TEST_SUITE=contractsMintedCappedCrowdsale
-  - TEST_SUITE=contractsDutchAuction
-  - TEST_SUITE=e2eMintedCappedCrowdsale
-  - TEST_SUITE=e2eDutchAuction
-install:
+cache:
+  directories:
+  - node_modules
+  - submodules/poa-web3-1.0
 
+env:
+  - TEST_SUITE=e2eMintedUI
+  - TEST_SUITE=e2eMintedWhitelist
+  - TEST_SUITE=e2eMintedMincap
+  - TEST_SUITE=e2eDutchUI
+  - TEST_SUITE=e2eDutchWhitelist
+  - TEST_SUITE=e2eDutchMincap
+  - TEST_SUITE=reactComponentTests
+
+install:
 
 before_script:
   - git submodule update --init --recursive --remote
@@ -23,14 +31,18 @@ before_script:
   - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
 
 script:
-  - npm run lint
-  - if [ $TEST_SUITE == 'contractsMintedCappedCrowdsale' ]; then npm run testContractsMintedCappedCrowdsale; fi
-  - if [ $TEST_SUITE == 'contractsDutchAuction' ]; then npm run testContractsDutchAuction ; fi
-  - if [ $TEST_SUITE == 'e2eMintedCappedCrowdsale' ]; then npm run e2eMintedCappedCrowdsale ; fi
-  - if [ $TEST_SUITE == 'e2eDutchAuction' ]; then npm run e2eDutchAuction && npm run coveralls; fi
+
+  - if [ $TEST_SUITE == 'e2eMintedUI' ]; then npm run e2eMintedUI ; fi
+  - if [ $TEST_SUITE == 'e2eMintedWhitelist' ]; then npm run e2eMintedWhitelist ; fi
+  - if [ $TEST_SUITE == 'e2eMintedMincap' ]; then npm run e2eMintedMincap ; fi
+  - if [ $TEST_SUITE == 'e2eDutchUI' ]; then npm run e2eDutchUI; fi
+  - if [ $TEST_SUITE == 'e2eDutchWhitelist' ]; then npm run e2eDutchWhitelist; fi
+  - if [ $TEST_SUITE == 'e2eDutchMincap' ]; then npm run e2eDutchMincap; fi
+  - if [ $TEST_SUITE == 'reactComponentTests' ]; then  npm run lint && npm run coveralls; fi
 
 after_script:
   - sudo kill `sudo lsof -t -i:8545`
 
 after_success:
   - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)
+

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -85,28 +85,26 @@ module.exports = {
           'git checkout -f master',
         ),
         MintedCappedCrowdsale: series(
-          'bash ./scripts/start_ganache.sh',
+          'nps test.prepare',
           'cd ./submodules/auth-os-applications',
-          'git checkout -f e2e',
           'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale/',
           'npm init -y',
           'npm i',
           'npm i authos-solidity',
           'nps test.deployContracts',
           'cd ../../../../../',
-          'bash ./scripts/stop_ganache.sh'
+          'nps test.e2e.stop'
         ),
         DutchAuction: series(
-          'bash ./scripts/start_ganache.sh',
+          'nps test.prepare',
           'cd ./submodules/auth-os-applications',
-          'git checkout -f e2e',
           'cd ./TokenWizard/crowdsale/DutchCrowdsale/',
           'npm init -y',
           'npm i',
           'npm i authos-solidity',
           'nps test.deployContracts',
           'cd ../../../../../',
-          'bash ./scripts/stop_ganache.sh'
+          'nps test.e2e.stop'
         ),
         e2e: {
           default: series(

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -142,7 +142,7 @@ module.exports = {
           'bash ./scripts/start_ganache.sh',
           'cd ./submodules/auth-os-applications',
           'git checkout -f e2e',
-          'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale',
+          'cd ./TokenWizard/crowdsale/DutchCrowdsale',
           'npm install',
           'npm i authos-solidity',
           'nps test.deployContracts',

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -77,41 +77,49 @@ module.exports = {
         ),
         Minted: series(
           'nps test.e2e.prepareMinted',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eMinted',
           'nps test.e2e.stop'
         ),
         MintedUI: series(
           'nps test.e2e.prepareMinted',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eMintedUI',
           'nps test.e2e.stop'
         ),
         MintedWhitelist: series(
           'nps test.e2e.prepareMinted',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eMintedWhitelist',
           'nps test.e2e.stop'
         ),
         MintedMincap: series(
           'nps test.e2e.prepareMinted',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eMintedMincap',
           'nps test.e2e.stop'
         ),
         Dutch: series(
           'nps test.e2e.prepareDutch',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eDutch',
           'nps test.e2e.stop'
         ),
         DutchUI: series(
           'nps test.e2e.prepareDutch',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eDutchUI',
           'nps test.e2e.stop'
         ),
         DutchWhitelist: series(
           'nps test.e2e.prepareDutch',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eDutchWhitelist',
           'nps test.e2e.stop'
         ),
         DutchMincap: series(
           'nps test.e2e.prepareDutch',
+          'cd submodules/token-wizard-test-automation',
           'npm run e2eDutchMincap',
           'nps test.e2e.stop'
         ),

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -157,7 +157,7 @@ module.exports = {
         stop: series(
           'cd ../../',
           'bash ./scripts/stop_ganache.sh',
-          'kill `lsof -t -i:3000`'
+          'kill ` lsof -t -i:3000`'
         )
       }
     }

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -27,14 +27,20 @@ module.exports = {
         ncp('./build/index.html ./build/stats.html')
       )
     },
+    dev: {
+      default: series(
+
+
+      )
+    },
 
     test: {
       default: series(
         'npm run installWeb3',
         'npm run testContractsMintedCappedCrowdsale',
         'npm run testContractsDutchAuction',
-        'npm run e2eMintedCappedCrowdsale',
-        'npm run e2eDutchAuction'
+        'npm run e2eMinted',
+        'npm run e2eDutch'
       ),
       deployContracts: series(
         'npm install truffle',
@@ -74,53 +80,64 @@ module.exports = {
       ),
       e2e: {
         default: series(
+          'nps test.e2e.Minted',
+          'nps test.e2e.Dutch'
         ),
         Minted: series(
           'nps test.e2e.prepareMinted',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eMinted',
+          'cd ../../',
           'nps test.e2e.stop'
         ),
         MintedUI: series(
           'nps test.e2e.prepareMinted',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eMintedUI',
+          'cd ../../',
           'nps test.e2e.stop'
         ),
         MintedWhitelist: series(
           'nps test.e2e.prepareMinted',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eMintedWhitelist',
+          'cd ../../',
           'nps test.e2e.stop'
         ),
         MintedMincap: series(
           'nps test.e2e.prepareMinted',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eMintedMincap',
+          'cd ../../',
           'nps test.e2e.stop'
         ),
         Dutch: series(
           'nps test.e2e.prepareDutch',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eDutch',
+          'cd ../../',
           'nps test.e2e.stop'
         ),
         DutchUI: series(
           'nps test.e2e.prepareDutch',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eDutchUI',
-          'nps test.e2e.stop'
+          'cd ../../',
+          'nps test.e2e.stop',
+
         ),
         DutchWhitelist: series(
           'nps test.e2e.prepareDutch',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eDutchWhitelist',
+          'cd ../../',
           'nps test.e2e.stop'
         ),
         DutchMincap: series(
           'nps test.e2e.prepareDutch',
           'cd submodules/token-wizard-test-automation',
           'npm run e2eDutchMincap',
+          'cd ../../',
           'nps test.e2e.stop'
         ),
         prepareMinted: series(
@@ -155,7 +172,6 @@ module.exports = {
         ),
         start: 'PORT=3000 BROWSER=none node scripts/start.js &',
         stop: series(
-          'cd ../../',
           'bash ./scripts/stop_ganache.sh',
           'kill ` lsof -t -i:3000`'
         )

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -29,118 +29,12 @@ module.exports = {
     },
     dev: {
       default: series(
-
-
-      )
-    },
-
-    test: {
-      default: series(
-        'npm run installWeb3',
-        'npm run testContractsMintedCappedCrowdsale',
-        'npm run testContractsDutchAuction',
-        'npm run e2eMinted',
-        'npm run e2eDutch'
+        'git submodule update --init --recursive --remote',
+        'npm run installWeb3'
       ),
-      deployContracts: series(
-        'npm install truffle',
-        'npm install solc',
-        './node_modules/.bin/truffle compile',
-        './node_modules/.bin/truffle migrate --network development',
-        './node_modules/.bin/truffle test --network development'
-      ),
-      prepare: series(
-        'bash ./scripts/start_ganache.sh',
-        'cd ./submodules/auth-os-applications/',
-        'git checkout -f master',
-      ),
-      MintedCappedCrowdsale: series(
-        'bash ./scripts/start_ganache.sh',
-        'cd ./submodules/auth-os-applications',
-        'git checkout -f e2e',
-        'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale/',
-        'npm init -y',
-        'npm i',
-        'npm i authos-solidity',
-        'nps test.deployContracts',
-        'cd ../../../../../',
-        'bash ./scripts/stop_ganache.sh'
-      ),
-      DutchAuction: series(
-        'bash ./scripts/start_ganache.sh',
-        'cd ./submodules/auth-os-applications',
-        'git checkout -f e2e',
-        'cd ./TokenWizard/crowdsale/DutchCrowdsale/',
-        'npm init -y',
-        'npm i',
-        'npm i authos-solidity',
-        'nps test.deployContracts',
-        'cd ../../../../../',
-        'bash ./scripts/stop_ganache.sh'
-      ),
-      e2e: {
+      Minted: {
         default: series(
-          'nps test.e2e.Minted',
-          'nps test.e2e.Dutch'
-        ),
-        Minted: series(
-          'nps test.e2e.prepareMinted',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eMinted',
-          'cd ../../',
-          'nps test.e2e.stop'
-        ),
-        MintedUI: series(
-          'nps test.e2e.prepareMinted',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eMintedUI',
-          'cd ../../',
-          'nps test.e2e.stop'
-        ),
-        MintedWhitelist: series(
-          'nps test.e2e.prepareMinted',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eMintedWhitelist',
-          'cd ../../',
-          'nps test.e2e.stop'
-        ),
-        MintedMincap: series(
-          'nps test.e2e.prepareMinted',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eMintedMincap',
-          'cd ../../',
-          'nps test.e2e.stop'
-        ),
-        Dutch: series(
-          'nps test.e2e.prepareDutch',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eDutch',
-          'cd ../../',
-          'nps test.e2e.stop'
-        ),
-        DutchUI: series(
-          'nps test.e2e.prepareDutch',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eDutchUI',
-          'cd ../../',
           'nps test.e2e.stop',
-
-        ),
-        DutchWhitelist: series(
-          'nps test.e2e.prepareDutch',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eDutchWhitelist',
-          'cd ../../',
-          'nps test.e2e.stop'
-        ),
-        DutchMincap: series(
-          'nps test.e2e.prepareDutch',
-          'cd submodules/token-wizard-test-automation',
-          'npm run e2eDutchMincap',
-          'cd ../../',
-          'nps test.e2e.stop'
-        ),
-        prepareMinted: series(
           'bash ./scripts/start_ganache.sh',
           'cd ./submodules/auth-os-applications',
           'git checkout -f e2e',
@@ -151,31 +45,168 @@ module.exports = {
           'cp .env ../../../../../.env',
           'cd ../../../../../',
           'nps test.e2e.start',
-          'npm run delay',
-          'cd submodules/token-wizard-test-automation',
-          'npm install'
+        )
+      },
+        Dutch: {
+          default: series(
+            'nps test.e2e.stop',
+            'bash ./scripts/start_ganache.sh',
+            'cd ./submodules/auth-os-applications',
+            'git checkout -f e2e',
+            'cd ./TokenWizard/crowdsale/DutchCrowdsale',
+            'npm install',
+            'npm i authos-solidity',
+            'nps test.deployContracts',
+            'cp .env ../../../../../.env',
+            'cd ../../../../../',
+            'nps test.e2e.start',
+          ),
+        }
+      },
+
+      test: {
+        default: series(
+          'npm run installWeb3',
+          'npm run testContractsMintedCappedCrowdsale',
+          'npm run testContractsDutchAuction',
+          'npm run e2eMinted',
+          'npm run e2eDutch'
         ),
-        prepareDutch: series(
+        deployContracts: series(
+          'npm install truffle',
+          'npm install solc',
+          './node_modules/.bin/truffle compile',
+          './node_modules/.bin/truffle migrate --network development',
+          './node_modules/.bin/truffle test --network development'
+        ),
+        prepare: series(
+          'bash ./scripts/start_ganache.sh',
+          'cd ./submodules/auth-os-applications/',
+          'git checkout -f master',
+        ),
+        MintedCappedCrowdsale: series(
           'bash ./scripts/start_ganache.sh',
           'cd ./submodules/auth-os-applications',
           'git checkout -f e2e',
-          'cd ./TokenWizard/crowdsale/DutchCrowdsale',
-          'npm install',
+          'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale/',
+          'npm init -y',
+          'npm i',
           'npm i authos-solidity',
           'nps test.deployContracts',
-          'cp .env ../../../../../.env',
           'cd ../../../../../',
-          'nps test.e2e.start',
-          'npm run delay',
-          'cd submodules/token-wizard-test-automation',
-          'npm install'
+          'bash ./scripts/stop_ganache.sh'
         ),
-        start: 'PORT=3000 BROWSER=none node scripts/start.js &',
-        stop: series(
-          'bash ./scripts/stop_ganache.sh',
-          'kill ` lsof -t -i:3000`'
-        )
+        DutchAuction: series(
+          'bash ./scripts/start_ganache.sh',
+          'cd ./submodules/auth-os-applications',
+          'git checkout -f e2e',
+          'cd ./TokenWizard/crowdsale/DutchCrowdsale/',
+          'npm init -y',
+          'npm i',
+          'npm i authos-solidity',
+          'nps test.deployContracts',
+          'cd ../../../../../',
+          'bash ./scripts/stop_ganache.sh'
+        ),
+        e2e: {
+          default: series(
+            'nps test.e2e.Minted',
+            'nps test.e2e.Dutch'
+          ),
+          Minted: series(
+            'nps test.e2e.prepareMinted',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eMinted',
+            'cd ../../',
+            'nps test.e2e.stop'
+          ),
+          MintedUI: series(
+            'nps test.e2e.prepareMinted',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eMintedUI',
+            'cd ../../',
+            'nps test.e2e.stop'
+          ),
+          MintedWhitelist: series(
+            'nps test.e2e.prepareMinted',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eMintedWhitelist',
+            'cd ../../',
+            'nps test.e2e.stop'
+          ),
+          MintedMincap: series(
+            'nps test.e2e.prepareMinted',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eMintedMincap',
+            'cd ../../',
+            'nps test.e2e.stop'
+          ),
+          Dutch: series(
+            'nps test.e2e.prepareDutch',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eDutch',
+            'cd ../../',
+            'nps test.e2e.stop'
+          ),
+          DutchUI: series(
+            'nps test.e2e.prepareDutch',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eDutchUI',
+            'cd ../../',
+            'nps test.e2e.stop',
+          ),
+          DutchWhitelist: series(
+            'nps test.e2e.prepareDutch',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eDutchWhitelist',
+            'cd ../../',
+            'nps test.e2e.stop'
+          ),
+          DutchMincap: series(
+            'nps test.e2e.prepareDutch',
+            'cd submodules/token-wizard-test-automation',
+            'npm run e2eDutchMincap',
+            'cd ../../',
+            'nps test.e2e.stop'
+          ),
+          prepareMinted: series(
+            'bash ./scripts/start_ganache.sh',
+            'cd ./submodules/auth-os-applications',
+            'git checkout -f e2e',
+            'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale',
+            'npm install',
+            'npm i authos-solidity',
+            'nps test.deployContracts',
+            'cp .env ../../../../../.env',
+            'cd ../../../../../',
+            'nps test.e2e.start',
+            'npm run delay',
+            'cd submodules/token-wizard-test-automation',
+            'npm install'
+          ),
+          prepareDutch: series(
+            'nps test.e2e.stop',
+            'bash ./scripts/start_ganache.sh',
+            'cd ./submodules/auth-os-applications',
+            'git checkout -f e2e',
+            'cd ./TokenWizard/crowdsale/DutchCrowdsale',
+            'npm install',
+            'npm i authos-solidity',
+            'nps test.deployContracts',
+            'cp .env ../../../../../.env',
+            'cd ../../../../../',
+            'nps test.e2e.start',
+            'npm run delay',
+            'cd submodules/token-wizard-test-automation',
+            'npm install'
+          ),
+          start: 'PORT=3000 BROWSER=none node scripts/start.js &',
+          stop: series(
+            'bash ./scripts/stop_ganache.sh',
+            'bash ./scripts/stop_port3000.sh'
+          )
+        }
       }
     }
   }
-}
+

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -27,6 +27,7 @@ module.exports = {
         ncp('./build/index.html ./build/stats.html')
       )
     },
+
     test: {
       default: series(
         'npm run installWeb3',
@@ -48,8 +49,9 @@ module.exports = {
         'git checkout -f master',
       ),
       MintedCappedCrowdsale: series(
-        'nps test.prepare',
-        'cd ./submodules/auth-os-applications/',
+        'bash ./scripts/start_ganache.sh',
+        'cd ./submodules/auth-os-applications',
+        'git checkout -f e2e',
         'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale/',
         'npm init -y',
         'npm i',
@@ -59,8 +61,9 @@ module.exports = {
         'bash ./scripts/stop_ganache.sh'
       ),
       DutchAuction: series(
-        'nps test.prepare',
-        'cd ./submodules/auth-os-applications/',
+        'bash ./scripts/start_ganache.sh',
+        'cd ./submodules/auth-os-applications',
+        'git checkout -f e2e',
         'cd ./TokenWizard/crowdsale/DutchCrowdsale/',
         'npm init -y',
         'npm i',
@@ -72,9 +75,50 @@ module.exports = {
       e2e: {
         default: series(
         ),
-        MintedCappedCrowdsale: series(
-          'nps test.e2e.prepare',
+        Minted: series(
+          'nps test.e2e.prepareMinted',
+          'npm run e2eMinted',
+          'nps test.e2e.stop'
+        ),
+        MintedUI: series(
+          'nps test.e2e.prepareMinted',
+          'npm run e2eMintedUI',
+          'nps test.e2e.stop'
+        ),
+        MintedWhitelist: series(
+          'nps test.e2e.prepareMinted',
+          'npm run e2eMintedWhitelist',
+          'nps test.e2e.stop'
+        ),
+        MintedMincap: series(
+          'nps test.e2e.prepareMinted',
+          'npm run e2eMintedMincap',
+          'nps test.e2e.stop'
+        ),
+        Dutch: series(
+          'nps test.e2e.prepareDutch',
+          'npm run e2eDutch',
+          'nps test.e2e.stop'
+        ),
+        DutchUI: series(
+          'nps test.e2e.prepareDutch',
+          'npm run e2eDutchUI',
+          'nps test.e2e.stop'
+        ),
+        DutchWhitelist: series(
+          'nps test.e2e.prepareDutch',
+          'npm run e2eDutchWhitelist',
+          'nps test.e2e.stop'
+        ),
+        DutchMincap: series(
+          'nps test.e2e.prepareDutch',
+          'npm run e2eDutchMincap',
+          'nps test.e2e.stop'
+        ),
+        prepareMinted: series(
+          'bash ./scripts/start_ganache.sh',
           'cd ./submodules/auth-os-applications',
+          'git checkout -f e2e',
           'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale',
           'npm install',
           'npm i authos-solidity',
@@ -84,16 +128,13 @@ module.exports = {
           'nps test.e2e.start',
           'npm run delay',
           'cd submodules/token-wizard-test-automation',
-          'npm install',
-          'npm run e2eMinted',
-          'cd ../../',
-          'bash ./scripts/stop_ganache.sh',
-          'kill `lsof -t -i:3000`'
+          'npm install'
         ),
-        DutchAuction: series(
-          'nps test.e2e.prepare',
+        prepareDutch: series(
+          'bash ./scripts/start_ganache.sh',
           'cd ./submodules/auth-os-applications',
-          'cd ./TokenWizard/crowdsale/DutchCrowdsale',
+          'git checkout -f e2e',
+          'cd ./TokenWizard/crowdsale/MintedCappedCrowdsale',
           'npm install',
           'npm i authos-solidity',
           'nps test.deployContracts',
@@ -102,18 +143,14 @@ module.exports = {
           'nps test.e2e.start',
           'npm run delay',
           'cd submodules/token-wizard-test-automation',
-          'npm install',
-          'npm run e2eDutch',
+          'npm install'
+        ),
+        start: 'PORT=3000 BROWSER=none node scripts/start.js &',
+        stop: series(
           'cd ../../',
           'bash ./scripts/stop_ganache.sh',
           'kill `lsof -t -i:3000`'
-        ),
-        prepare: series(
-          'bash ./scripts/start_ganache.sh',
-          'cd ./submodules/auth-os-applications',
-          'git checkout -f e2e'
-        ),
-        start: 'PORT=3000 BROWSER=none node scripts/start.js &'
+        )
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -124,9 +124,9 @@
   "scripts": {
     "installWeb3": "cd submodules/poa-web3-1.0 && npm install && cd ../../ && npm install --no-save submodules/poa-web3-1.0/packages/web3",
     "start": "npm run installWeb3 && node scripts/start.js",
-
     "dev": "nps dev",
-
+    "dev:minted": "nps dev.Minted",
+    "dev:dutch": "nps dev.Dutch",
     "deployRegistry": "node scripts/deployRegistry.js",
     "build": "nps build",
     "sass:watch": "gulp watch",
@@ -135,7 +135,6 @@
     "lint": "eslint src",
     "ganache": "ganache-cli -d -i 12648430",
     "precommit": "pretty-quick staged",
-
     "coveralls": "jest --env=jsdom --coverage -w='2' && cat coverage/lcov.info | coveralls",
     "test:e2e": "nps test.e2e",
     "test:dapp": "jest --env=jsdom -w='2'",
@@ -150,9 +149,7 @@
     "e2eDutchUI": "nps test.e2e.DutchUI",
     "e2eDutchWhitelist": "nps test.e2e.DutchWhitelist",
     "e2eDutchMincap": "nps test.e2e.DutchMincap",
-    "prepareMinted": "nps test.e2e.prepareMinted",
-    "prepareDutch": "nps test.e2e.prepareDutch",
-    "stop":"nps test.e2e.stop"
+    "stop": "nps test.e2e.stop"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -124,26 +124,24 @@
   "scripts": {
     "installWeb3": "cd submodules/poa-web3-1.0 && npm install && cd ../../ && npm install --no-save submodules/poa-web3-1.0/packages/web3",
     "start": "npm run installWeb3 && node scripts/start.js",
+
     "dev": "nps dev",
-    "dev:fast": "nps dev.fast",
+
     "deployRegistry": "node scripts/deployRegistry.js",
     "build": "nps build",
     "sass:watch": "gulp watch",
     "sass:update": "gulp sass",
-    "test": "nps test",
-    "testContractsDutchAuction": "nps test.DutchAuction",
-    "testContractsMintedCappedCrowdsale": "nps test.MintedCappedCrowdsale",
-    "test:dapp": "jest --env=jsdom -w='2'",
-    "e2e-prepare-start": "nps test.e2e.prepare",
-    "e2e-start": "nps test.e2e.start",
     "delay": "node ./node_modules/npm-delay 30000",
-    "test:e2e": "nps test.e2e",
-    "coveralls": "jest --env=jsdom --coverage -w='2' && cat coverage/lcov.info | coveralls",
-    "generateContracts": "nps contracts.generate",
-    "compileContracts": "nps contracts.compile",
     "lint": "eslint src",
     "ganache": "ganache-cli -d -i 12648430",
     "precommit": "pretty-quick staged",
+
+    "coveralls": "jest --env=jsdom --coverage -w='2' && cat coverage/lcov.info | coveralls",
+    "test:e2e": "nps test.e2e",
+    "test:dapp": "jest --env=jsdom -w='2'",
+    "test": "nps test",
+    "testContractsDutchAuction": "nps test.DutchAuction",
+    "testContractsMintedCappedCrowdsale": "nps test.MintedCappedCrowdsale",
     "e2eMinted": "nps test.e2e.Minted",
     "e2eMintedUI": "nps test.e2e.MintedUI",
     "e2eMintedWhitelist": "nps test.e2e.MintedWhitelist",
@@ -151,7 +149,10 @@
     "e2eDutch": "nps test.e2e.Dutch",
     "e2eDutchUI": "nps test.e2e.DutchUI",
     "e2eDutchWhitelist": "nps test.e2e.DutchWhitelist",
-    "e2eDutchMincap": "nps test.e2e.DutchMincap"
+    "e2eDutchMincap": "nps test.e2e.DutchMincap",
+    "prepareMinted": "nps test.e2e.prepareMinted",
+    "prepareDutch": "nps test.e2e.prepareDutch",
+    "stop":"nps test.e2e.stop"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -133,8 +133,6 @@
     "test": "nps test",
     "testContractsDutchAuction": "nps test.DutchAuction",
     "testContractsMintedCappedCrowdsale": "nps test.MintedCappedCrowdsale",
-    "e2eDutchAuction": "nps test.e2e.DutchAuction",
-    "e2eMintedCappedCrowdsale": "nps test.e2e.MintedCappedCrowdsale",
     "test:dapp": "jest --env=jsdom -w='2'",
     "e2e-prepare-start": "nps test.e2e.prepare",
     "e2e-start": "nps test.e2e.start",
@@ -145,7 +143,15 @@
     "compileContracts": "nps contracts.compile",
     "lint": "eslint src",
     "ganache": "ganache-cli -d -i 12648430",
-    "precommit": "pretty-quick staged"
+    "precommit": "pretty-quick staged",
+    "e2eMinted": "nps test.e2e.Minted",
+    "e2eMintedUI": "nps test.e2e.MintedUI",
+    "e2eMintedWhitelist": "nps test.e2e.MintedWhitelist",
+    "e2eMintedMincap": "nps test.e2e.MintedMincap",
+    "e2eDutch": "nps test.e2e.Dutch",
+    "e2eDutchUI": "nps test.e2e.DutchUI",
+    "e2eDutchWhitelist": "nps test.e2e.DutchWhitelist",
+    "e2eDutchMincap": "nps test.e2e.DutchMincap"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/scripts/stop_port3000.sh
+++ b/scripts/stop_port3000.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#set -x
+set -u
+set -e
+
+port=3000
+
+
+function kill_process {
+	if lsof -t -i:$1 > /dev/null
+	then
+		kill -9 $(lsof -t -i:${1})
+	   	echo 1
+	else
+		echo 0
+	fi
+}
+
+kill_process $port


### PR DESCRIPTION
- e2e tests are  splitted into six parts
- individual  travis job for react components tests
- removed unused scripts from package.json
- refactored scripts in package-scripts.js
- refactored travis.yml: added cache option, job is splitted into 7 parts 