### PR TITLE
(Bug) Reserved addresses are not initialized if list length > 20

### DIFF
--- a/src/components/stepTwo/StepTwoForm.js
+++ b/src/components/stepTwo/StepTwoForm.js
@@ -24,6 +24,7 @@ export const StepTwoForm = ({
   tokens,
   decimals,
   addReservedTokensItem,
+  validateReservedTokensList,
   removeReservedToken,
   clearAll,
   crowdsaleStore,
@@ -46,6 +47,7 @@ export const StepTwoForm = ({
         decimals={decimals}
         addReservedTokensItem={addReservedTokensItem}
         removeReservedToken={removeReservedToken}
+        validateReservedTokensList={validateReservedTokensList}
         clearAll={clearAll}
       />
     </div>

--- a/src/components/stepTwo/index.js
+++ b/src/components/stepTwo/index.js
@@ -3,14 +3,17 @@ import '../../assets/stylesheets/application.css'
 import { checkWeb3 } from '../../utils/blockchainHelpers'
 import { StepNavigation } from '../Common/StepNavigation'
 import { Loader } from '../Common/Loader'
-import { clearingReservedTokens } from '../../utils/alerts'
+import { clearingReservedTokens, noMoreReservedSlotAvailable } from '../../utils/alerts'
 import { NAVIGATION_STEPS, VALIDATION_TYPES } from '../../utils/constants'
 import { inject, observer } from 'mobx-react'
 import { Form } from 'react-final-form'
 import { StepTwoForm } from './StepTwoForm'
+import logdown from 'logdown'
 
 const { TOKEN_SETUP } = NAVIGATION_STEPS
 const { VALID, INVALID } = VALIDATION_TYPES
+
+const logger = logdown('TW:stepTwo:index')
 
 @inject('tokenStore', 'crowdsaleStore', 'web3Store', 'reservedTokenStore')
 @observer
@@ -49,6 +52,16 @@ export class stepTwo extends Component {
     if (result && result.value) {
       reservedTokenStore.clearAll()
     }
+  }
+
+  validateReservedTokensList = async () => {
+    const { reservedTokenStore } = this.props
+
+    let result = reservedTokenStore.validateLength
+    if (!result) {
+      await noMoreReservedSlotAvailable()
+    }
+    return result
   }
 
   addReservedTokensItem = newToken => {
@@ -93,6 +106,7 @@ export class stepTwo extends Component {
             tokens={reservedTokenStore.tokens}
             decimals={decimals}
             addReservedTokensItem={this.addReservedTokensItem}
+            validateReservedTokensList={this.validateReservedTokensList}
             removeReservedToken={this.removeReservedToken}
             clearAll={this.clearReservedTokens}
             id="tokenData"

--- a/src/stores/ReservedTokenStore.js
+++ b/src/stores/ReservedTokenStore.js
@@ -1,6 +1,7 @@
 import { observable, action } from 'mobx'
 import autosave from './autosave'
 import { computed } from 'mobx/lib/mobx'
+import { LIMIT_RESERVED_ADDRESSES } from '../utils/constants'
 
 class ReservedTokenStore {
   @observable tokens
@@ -56,7 +57,7 @@ class ReservedTokenStore {
 
   @computed
   get validateLength() {
-    return this.tokens.length < 20
+    return this.tokens.length < LIMIT_RESERVED_ADDRESSES
   }
 }
 

--- a/src/stores/ReservedTokenStore.js
+++ b/src/stores/ReservedTokenStore.js
@@ -1,5 +1,6 @@
 import { observable, action } from 'mobx'
 import autosave from './autosave'
+import { computed } from 'mobx/lib/mobx'
 
 class ReservedTokenStore {
   @observable tokens
@@ -51,6 +52,11 @@ class ReservedTokenStore {
 
       return false
     })
+  }
+
+  @computed
+  get validateLength() {
+    return this.tokens.length < 20
   }
 }
 

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -290,7 +290,7 @@ export function noMoreReservedSlotAvailable() {
 export function noMoreReservedSlotAvailableCSV(count) {
   return sweetAlert2({
     title: 'You reach the limit of reserved tokens',
-    html: `You're not able to reserve more tokens. Only ${count} reserved address of the file could be added`,
+    html: `You're not able to reserve more tokens. Only ${count} reserved addresses of the file could be added`,
     type: 'info'
   })
 }

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -1,6 +1,6 @@
 import sweetAlert2 from 'sweetalert2'
 import { weiToGwei } from './utils'
-import { DEPLOYMENT_VALUES } from './constants'
+import { DEPLOYMENT_VALUES, LIMIT_RESERVED_ADDRESSES } from './constants'
 
 export function noMetaMaskAlert() {
   sweetAlert2({
@@ -282,7 +282,7 @@ export function notAllowedContributor() {
 export function noMoreReservedSlotAvailable() {
   return sweetAlert2({
     title: 'No more reserved tokens available',
-    html: `You're not able to reserve more tokens. The maximum allowed is 20`,
+    html: `You're not able to reserve more tokens. The maximum allowed is ${LIMIT_RESERVED_ADDRESSES}`,
     type: 'info'
   })
 }

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -278,3 +278,19 @@ export function notAllowedContributor() {
     type: 'info'
   })
 }
+
+export function noMoreReservedSlotAvailable() {
+  return sweetAlert2({
+    title: 'No more reserved tokens available',
+    html: `You're not able to reserve more tokens. The maximum allowed is 20`,
+    type: 'info'
+  })
+}
+
+export function noMoreReservedSlotAvailableCSV(count) {
+  return sweetAlert2({
+    title: 'You reach the limit of reserved tokens',
+    html: `You're not able to reserve more tokens. Only ${count} reserved address of the file could be added`,
+    type: 'info'
+  })
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -281,3 +281,9 @@ export const TOAST = {
     time: 10000
   }
 }
+
+/**
+ * Limit for reserved addresses, validated in the contract
+ * @type {number}
+ */
+export const LIMIT_RESERVED_ADDRESSES = 20

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -295,4 +295,3 @@ export const DOWNLOAD_STATUS = {
  * @type {number}
  */
 export const LIMIT_RESERVED_ADDRESSES = 20
-


### PR DESCRIPTION
Closes #1048 

There is a limitation based on the contracts, see image
![screenshot_20180726_141508](https://user-images.githubusercontent.com/1144028/43283506-772e197c-90ef-11e8-83d9-75119461248c.png)

When you upload a file that exceeds 20 addresses, a message like this should appear, see image
![screenshot_20180726_161613](https://user-images.githubusercontent.com/1144028/43283565-9de3140a-90ef-11e8-983d-74bcef48d8ce.png)

- Added two new alerts to manage reserved slot address
- Add validation in the ReservedTokenStore
- Refactoring applying new validation
