### PR TITLE
(Bug) Minted, Dutch: Whitelisted addresses are not initialized if list length > 60

### DIFF
--- a/src/components/Common/WhitelistInputBlock.js
+++ b/src/components/Common/WhitelistInputBlock.js
@@ -8,9 +8,17 @@ import { InputField } from './InputField'
 import { TEXT_FIELDS, VALIDATION_MESSAGES, VALIDATION_TYPES } from '../../utils/constants'
 import { WhitelistItem } from './WhitelistItem'
 import { inject, observer } from 'mobx-react'
-import { clearingWhitelist, whitelistImported } from '../../utils/alerts'
+import {
+  clearingWhitelist,
+  whitelistImported,
+  noMoreWhitelistedSlotAvailable,
+  noMoreWhitelistedSlotAvailableCSV
+} from '../../utils/alerts'
 import processWhitelist from '../../utils/processWhitelist'
 import { validateWhitelistMax, validateWhitelistMin } from '../../utils/validations'
+import logdown from 'logdown'
+
+const logger = logdown('TW:WhitelistInputBlock')
 const { ADDRESS, MIN, MAX } = TEXT_FIELDS
 const { VALID, INVALID } = VALIDATION_TYPES
 
@@ -42,10 +50,27 @@ export class WhitelistInputBlock extends React.Component {
     }
   }
 
-  addWhitelistItem = () => {
+  validateWhitelistedAddressList = async tierIndex => {
+    const { tierStore } = this.props
+
+    let result = tierStore.validateWhitelistedAddressLength(tierIndex)
+    if (!result) {
+      await noMoreWhitelistedSlotAvailable()
+    }
+    return result
+  }
+
+  addWhitelistItem = async () => {
     const { tierStore } = this.props
     const crowdsaleNum = this.props.num
     const { addr, min, max } = this.state
+
+    let validateWhitelistedLength = await this.validateWhitelistedAddressList(crowdsaleNum)
+    logger.log('Validate whitelisted address list length', validateWhitelistedLength)
+    if (!validateWhitelistedLength) {
+      this.clearInput()
+      return
+    }
 
     this.setState(
       update(this.state, {
@@ -183,23 +208,39 @@ export class WhitelistInputBlock extends React.Component {
   }
 
   onDrop = (acceptedFiles, rejectedFiles) => {
+    const { decimals, tierStore, num } = this.props
     acceptedFiles.forEach(file => {
       Papa.parse(file, {
         skipEmptyLines: true,
         complete: results => {
-          const { called } = processWhitelist(
+          const { called, whitelistedAddressLengthError } = processWhitelist(
             {
               rows: results.data,
-              decimals: this.props.decimals
+              decimals: decimals
             },
             item => {
-              this.props.tierStore.addWhitelistItem(item, this.props.num)
+              tierStore.addWhitelistItem(item, num)
+            },
+            () => {
+              return tierStore.validateWhitelistedAddressLength(num)
             }
           )
 
-          whitelistImported(called)
+          if (whitelistedAddressLengthError) {
+            noMoreWhitelistedSlotAvailableCSV(called)
+          } else {
+            whitelistImported(called)
+          }
         }
       })
+    })
+  }
+
+  clearInput() {
+    this.setState({
+      addr: '',
+      min: '',
+      max: ''
     })
   }
 

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -1,5 +1,5 @@
 import { observable, action, computed } from 'mobx'
-import { defaultTier, defaultTierValidations, VALIDATION_TYPES } from '../utils/constants'
+import { defaultTier, defaultTierValidations, VALIDATION_TYPES, LIMIT_WHITELISTED_ADDRESSES } from '../utils/constants'
 import { validateTime, validateSupply, validateLaterTime, validateLaterOrEqualTime, validateTier } from '../utils/utils'
 import autosave from './autosave'
 import { defaultCompanyEndDate, defaultCompanyStartDate } from '../components/stepThree/utils'
@@ -306,6 +306,15 @@ class TierStore {
   @computed
   get modifiedStoredWhitelist() {
     return this.tiers.some(tier => tier.whitelist.some(item => !item.stored))
+  }
+
+  /**
+   * Validate whitelisted for a given tier
+   * @param tierIndex
+   * @returns {boolean}
+   */
+  validateWhitelistedAddressLength(tierIndex) {
+    return this.tiers[tierIndex].whitelist.length < LIMIT_WHITELISTED_ADDRESSES
   }
 }
 

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -297,7 +297,7 @@ export function noMoreReservedSlotAvailableCSV(count) {
 
 export function noMoreWhitelistedSlotAvailable() {
   return sweetAlert2({
-    title: 'No more addresses available',
+    title: 'Maximum limit of addresses reached',
     html: `You're not able to add more addresses to the whitelist. The maximum allowed is ${LIMIT_WHITELISTED_ADDRESSES}`,
     type: 'info'
   })
@@ -305,7 +305,7 @@ export function noMoreWhitelistedSlotAvailable() {
 
 export function noMoreWhitelistedSlotAvailableCSV(count) {
   return sweetAlert2({
-    title: 'You reach the limit of addresses',
+    title: 'Maximum limit of addresses reached',
     html: `You're not able to add more addresses to the whitelist. Only ${count} addresses of the file could be added. The maximum allowed is ${LIMIT_WHITELISTED_ADDRESSES}`,
     type: 'info'
   })

--- a/src/utils/alerts.js
+++ b/src/utils/alerts.js
@@ -1,6 +1,6 @@
 import sweetAlert2 from 'sweetalert2'
 import { weiToGwei } from './utils'
-import { DEPLOYMENT_VALUES, LIMIT_RESERVED_ADDRESSES } from './constants'
+import { DEPLOYMENT_VALUES, LIMIT_RESERVED_ADDRESSES, LIMIT_WHITELISTED_ADDRESSES } from './constants'
 
 export function noMetaMaskAlert() {
   sweetAlert2({
@@ -290,7 +290,23 @@ export function noMoreReservedSlotAvailable() {
 export function noMoreReservedSlotAvailableCSV(count) {
   return sweetAlert2({
     title: 'You reach the limit of reserved tokens',
-    html: `You're not able to reserve more tokens. Only ${count} reserved addresses of the file could be added`,
+    html: `You're not able to reserve more tokens. Only ${count} reserved addresses of the file could be added. The maximum allowed is ${LIMIT_RESERVED_ADDRESSES}`,
+    type: 'info'
+  })
+}
+
+export function noMoreWhitelistedSlotAvailable() {
+  return sweetAlert2({
+    title: 'No more addresses available',
+    html: `You're not able to add more addresses to the whitelist. The maximum allowed is ${LIMIT_WHITELISTED_ADDRESSES}`,
+    type: 'info'
+  })
+}
+
+export function noMoreWhitelistedSlotAvailableCSV(count) {
+  return sweetAlert2({
+    title: 'You reach the limit of addresses',
+    html: `You're not able to add more addresses to the whitelist. Only ${count} addresses of the file could be added. The maximum allowed is ${LIMIT_WHITELISTED_ADDRESSES}`,
     type: 'info'
   })
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -284,6 +284,10 @@ export const TOAST = {
   }
 }
 
+/**
+ * Mobx status save contracts to localstorage
+ * @type {{PENDING: string, SUCCESS: string, FAILURE: string}}
+ */
 export const DOWNLOAD_STATUS = {
   PENDING: 'pending',
   SUCCESS: 'success',
@@ -295,3 +299,9 @@ export const DOWNLOAD_STATUS = {
  * @type {number}
  */
 export const LIMIT_RESERVED_ADDRESSES = 20
+
+/**
+ * Limit for whitelisted addresses
+ * @type {number}
+ */
+export const LIMIT_WHITELISTED_ADDRESSES = 2

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -304,4 +304,4 @@ export const LIMIT_RESERVED_ADDRESSES = 20
  * Limit for whitelisted addresses
  * @type {number}
  */
-export const LIMIT_WHITELISTED_ADDRESSES = 2
+export const LIMIT_WHITELISTED_ADDRESSES = 50

--- a/src/utils/processWhitelist.js
+++ b/src/utils/processWhitelist.js
@@ -8,12 +8,22 @@ import { isAddress, validateWhitelistMin, validateWhitelistMax } from './validat
  * `[address, min, max]`, for example: `['0x1234567890123456789012345678901234567890', '1', '10']`
  * @param {Number} whitelistInformation.decimals Amount of decimals allowed for the min and max values
  * @param {Function} cb The function to be called with each valid item
+ * @param {Function} cbValidation The function to be called to validate length
  * @returns {Object} Object with a `called` property, indicating the number of times the callback was called
  */
-export default function({ rows, decimals }, cb) {
+export default function({ rows, decimals }, cb, cbValidation) {
   let called = 0
-  rows.forEach(row => {
-    if (row.length !== 3) return
+  let whitelistedAddressLengthError = false
+  for (let row of rows) {
+    let validLength = cbValidation()
+    if (!validLength) {
+      whitelistedAddressLengthError = true
+      break
+    }
+
+    if (row.length !== 3) {
+      continue
+    }
 
     const [addr, min, max] = row
 
@@ -21,12 +31,16 @@ export default function({ rows, decimals }, cb) {
       isAddress()(addr) ||
       validateWhitelistMin({ min, max, decimals }) ||
       validateWhitelistMax({ min, max, decimals })
-    )
-      return
+    ) {
+      continue
+    }
 
     cb({ addr, min, max })
     called++
-  })
+  }
 
-  return { called }
+  return {
+    called: called,
+    whitelistedAddressLengthError: whitelistedAddressLengthError
+  }
 }


### PR DESCRIPTION
Closes #1052 

The problem is also reproducible with values ​​lower than 60, and it is random
sometimes 59, sometimes 58, sometimes 60. I take the decision to put a limit of 50

- Add constant to limit whitelisted addresses to 50
- Add two new alerts for whitelisted addresses, when the validation is applied
- Refactor processWhitelist function
- Add function to validate whitelisted addresses length
- Apply whitelist validation to the component