### PR TITLE
(Bug) Keep data between the steps (Step 3)

### DIFF
--- a/src/components/Common/ButtonContinue.js
+++ b/src/components/Common/ButtonContinue.js
@@ -7,13 +7,13 @@ export class ButtonContinue extends Component {
    * @returns {*}
    */
   render() {
-    const { status, type } = this.props
+    const { status, type, onClick } = this.props
     const submitButtonClass = classNames('button', 'button_fill', 'button_no_border', {
       button_disabled: !status
     })
 
     return (
-      <button type={type} disabled={!status} className={submitButtonClass}>
+      <button onClick={onClick} type={type} disabled={!status} className={submitButtonClass}>
         Continue
       </button>
     )

--- a/src/components/Common/DutchAuctionBlock.js
+++ b/src/components/Common/DutchAuctionBlock.js
@@ -69,6 +69,14 @@ export const DutchAuctionBlock = inject('tierStore', 'tokenStore')(
       return composeValidators(...listOfValidations)(value)
     }
 
+    const onChangeWhitelisted = (value, input, index) => {
+      //Clear whitelist
+      if (tierStore) {
+        tierStore.emptyWhitelist(index)
+      }
+      return input.onChange(value)
+    }
+
     return (
       <div>
         {fields.map((name, index) => (
@@ -153,7 +161,10 @@ export const DutchAuctionBlock = inject('tierStore', 'tokenStore')(
                   side="left"
                   label={SUPPLY_SHORT}
                   description={DESCRIPTION.SUPPLY}
-                  disabled={tierStore && tierStore.tiers[index].whitelist.length}
+                  disabled={
+                    (tierStore && tierStore.tiers[index].whitelistEnabled === 'yes') ||
+                    (tierStore && tierStore.tiers[index].whitelist.length)
+                  }
                 />
                 <Field
                   name={`${name}.whitelistEnabled`}
@@ -166,7 +177,7 @@ export const DutchAuctionBlock = inject('tierStore', 'tokenStore')(
                             type="radio"
                             checked={input.value === 'yes'}
                             value="yes"
-                            onChange={() => input.onChange('yes')}
+                            onChange={() => onChangeWhitelisted('yes', input, index)}
                           />
                           <span className="title">yes</span>
                         </label>
@@ -175,7 +186,7 @@ export const DutchAuctionBlock = inject('tierStore', 'tokenStore')(
                             type="radio"
                             checked={input.value === 'no'}
                             value="no"
-                            onChange={() => input.onChange('no')}
+                            onChange={() => onChangeWhitelisted('no', input, index)}
                           />
                           <span className="title">no</span>
                         </label>

--- a/src/components/Common/TierBlock.js
+++ b/src/components/Common/TierBlock.js
@@ -21,6 +21,14 @@ const inputErrorStyle = {
 }
 
 export const TierBlock = ({ fields, ...props }) => {
+  const onChangeWhitelisted = (value, input, index) => {
+    //Clear whitelist
+    if (props.tierStore) {
+      props.tierStore.emptyWhitelist(index)
+    }
+    return input.onChange(value)
+  }
+
   return (
     <div>
       {fields.map((name, index) => (
@@ -90,7 +98,7 @@ export const TierBlock = ({ fields, ...props }) => {
                           type="radio"
                           checked={input.value === 'yes'}
                           value="yes"
-                          onChange={() => input.onChange('yes')}
+                          onChange={() => onChangeWhitelisted('yes', input, index)}
                         />
                         <span className="title">yes</span>
                       </label>
@@ -100,7 +108,7 @@ export const TierBlock = ({ fields, ...props }) => {
                           type="radio"
                           checked={input.value === 'no'}
                           value="no"
-                          onChange={() => input.onChange('no')}
+                          onChange={() => onChangeWhitelisted('no', input, index)}
                         />
                         <span className="title">no</span>
                       </label>
@@ -128,7 +136,10 @@ export const TierBlock = ({ fields, ...props }) => {
                 name={`${name}.supply`}
                 errorStyle={inputErrorStyle}
                 side="right"
-                disabled={props.tierStore && props.tierStore.tiers[index].whitelist.length}
+                disabled={
+                  (props.tierStore && props.tierStore.tiers[index].whitelistEnabled === 'yes') ||
+                  (props.tierStore && props.tierStore.tiers[index].whitelist.length)
+                }
               />
             </div>
             <div className="input-block-container">

--- a/src/components/stepThree/GasPriceInput.js
+++ b/src/components/stepThree/GasPriceInput.js
@@ -83,6 +83,7 @@ class GasPriceInput extends Component {
   }
 
   compareChecked = value => {
+    // eslint-disable-next-line
     return new String(this.state.gasTypeSelected.id).valueOf() === new String(value).valueOf()
   }
 

--- a/src/components/stepThree/GasPriceInput.js
+++ b/src/components/stepThree/GasPriceInput.js
@@ -71,15 +71,7 @@ class GasPriceInput extends Component {
       customGasPrice: value
     })
 
-    input.onChange(
-      Object.assign(
-        {},
-        {
-          id: GAS_PRICE.CUSTOM.ID,
-          price: value
-        }
-      )
-    )
+    input.onChange(gasTypeSelected)
   }
 
   compareChecked = value => {

--- a/src/components/stepThree/GasPriceInput.js
+++ b/src/components/stepThree/GasPriceInput.js
@@ -9,7 +9,7 @@ import { inject, observer } from 'mobx-react'
 class GasPriceInput extends Component {
   state = {
     isCustom: false,
-    customGasPrice: 0,
+    customGasPrice: 0.1,
     gasTypeSelected: {}
   }
 
@@ -35,18 +35,10 @@ class GasPriceInput extends Component {
     const gasTypeSelected = objectKeysToLowerCase(value)
     this.handleGasType(gasTypeSelected)
 
-    input.onChange(
-      Object.assign(
-        {},
-        {
-          id: gasTypeSelected.id,
-          price: gasTypeSelected.price
-        }
-      )
-    )
+    input.onChange(gasTypeSelected)
   }
 
-  handleCustomSelected = () => {
+  handleCustomSelected = value => {
     const { input } = this.props
     this.setState({
       isCustom: true

--- a/src/components/stepThree/GasPriceInput.js
+++ b/src/components/stepThree/GasPriceInput.js
@@ -27,16 +27,27 @@ class GasPriceInput extends Component {
   }
 
   handleNonCustomSelected = value => {
+    const { input } = this.props
     this.setState({
       isCustom: false
     })
 
     const gasTypeSelected = objectKeysToLowerCase(value)
     this.handleGasType(gasTypeSelected)
-    this.props.input.onChange(gasTypeSelected)
+
+    input.onChange(
+      Object.assign(
+        {},
+        {
+          id: gasTypeSelected.id,
+          price: gasTypeSelected.price
+        }
+      )
+    )
   }
 
   handleCustomSelected = () => {
+    const { input } = this.props
     this.setState({
       isCustom: true
     })
@@ -47,7 +58,15 @@ class GasPriceInput extends Component {
     }
 
     this.handleGasType(gasTypeSelected)
-    this.props.input.onChange(gasTypeSelected)
+    input.onChange(
+      Object.assign(
+        {},
+        {
+          id: gasTypeSelected.id,
+          price: gasTypeSelected.price
+        }
+      )
+    )
   }
 
   handleGasType = value => {
@@ -71,7 +90,15 @@ class GasPriceInput extends Component {
       customGasPrice: value
     })
 
-    input.onChange(gasTypeSelected)
+    input.onChange(
+      Object.assign(
+        {},
+        {
+          id: gasTypeSelected.id,
+          price: value
+        }
+      )
+    )
   }
 
   compareChecked = value => {

--- a/src/components/stepThree/GasPriceInput.js
+++ b/src/components/stepThree/GasPriceInput.js
@@ -9,7 +9,7 @@ import { inject, observer } from 'mobx-react'
 class GasPriceInput extends Component {
   state = {
     isCustom: false,
-    customGasPrice: 0.1,
+    customGasPrice: GAS_PRICE.CUSTOM.PRICE,
     gasTypeSelected: {}
   }
 

--- a/src/components/stepThree/StepThreeFormDutchAuction.js
+++ b/src/components/stepThree/StepThreeFormDutchAuction.js
@@ -67,6 +67,7 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
         form.mutators.setFieldTouched(`tiers[${index}].updatable`, true)
         form.mutators.setFieldTouched(`tiers[${index}].whitelistEnabled`, true)
         form.mutators.setFieldTouched(`tiers[${index}].startTime`, true)
+        form.mutators.setFieldTouched(`tiers[${index}].rate`, true)
         form.mutators.setFieldTouched(`tiers[${index}].endTime`, true)
         form.mutators.setFieldTouched(`tiers[${index}].minRate`, true)
         form.mutators.setFieldTouched(`tiers[${index}].maxRate`, true)
@@ -163,6 +164,7 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
               </div>
             </div>
             <Field
+              id="gasPrice"
               name="gasPrice"
               component={GasPriceInput}
               side="right"

--- a/src/components/stepThree/StepThreeFormDutchAuction.js
+++ b/src/components/stepThree/StepThreeFormDutchAuction.js
@@ -4,8 +4,8 @@ import { FieldArray } from 'react-final-form-arrays'
 import { WhenFieldChanges } from '../Common/WhenFieldChanges'
 import { InputField2 } from '../Common/InputField2'
 import GasPriceInput from './GasPriceInput'
+import { ButtonContinue } from '../Common/ButtonContinue'
 import { gweiToWei } from '../../utils/utils'
-import classnames from 'classnames'
 import {
   composeValidators,
   isAddress,
@@ -33,10 +33,17 @@ const inputErrorStyle = {
   height: '20px'
 }
 
-export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, pristine, ...props }) => {
-  const submitButtonClass = classnames('button', 'button_fill', {
-    button_disabled: pristine || invalid
-  })
+export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, pristine, ...props }) => {
+  const status = !(submitting || invalid)
+
+  /**
+   * Set gas type selected on gas price input
+   * @param value
+   */
+  const updateGasTypeSelected = value => {
+    const { generalStore } = props
+    generalStore.setGasTypeSelected(value)
+  }
 
   const handleOnChange = ({ values }) => {
     props.tierStore.updateWalletAddress(values.walletAddress, VALID)
@@ -125,6 +132,7 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, pristine, ...
               component={GasPriceInput}
               side="right"
               gasPrices={props.gasPricesInGwei}
+              updateGasTypeSelected={updateGasTypeSelected}
               validate={value =>
                 composeValidators(
                   isDecimalPlacesNotGreaterThan(VALIDATION_MESSAGES.DECIMAL_PLACES_9)(9),
@@ -141,9 +149,7 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, pristine, ...
       </FieldArray>
 
       <div className="button-container">
-        <span onClick={handleSubmit} className={submitButtonClass}>
-          Continue
-        </span>
+        <ButtonContinue onClick={handleSubmit} status={status} />
       </div>
 
       <FormSpy subscription={{ values: true }} onChange={handleOnChange} />

--- a/src/components/stepThree/StepThreeFormDutchAuction.js
+++ b/src/components/stepThree/StepThreeFormDutchAuction.js
@@ -48,7 +48,7 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
   const handleValidateGasPrice = value => {
     const errors = composeValidators(
       isDecimalPlacesNotGreaterThan(VALIDATION_MESSAGES.DECIMAL_PLACES_9)(9),
-      isGreaterOrEqualThan(VALIDATION_MESSAGES.NUMBER_GREATER_THAN)(0.1)
+      isGreaterOrEqualThan(VALIDATION_MESSAGES.NUMBER_GREATER_OR_EQUAL_THAN)(0.1)
     )(value.price)
     if (errors) return errors.shift()
   }

--- a/src/components/stepThree/StepThreeFormDutchAuction.js
+++ b/src/components/stepThree/StepThreeFormDutchAuction.js
@@ -41,8 +41,8 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
    * @param value
    */
   const updateGasTypeSelected = value => {
-    const { generalStore } = props
-    generalStore.setGasTypeSelected(value)
+    const { updateGasTypeSelected } = props
+    updateGasTypeSelected(value)
   }
 
   const handleValidateGasPrice = value => {

--- a/src/components/stepThree/StepThreeFormDutchAuction.js
+++ b/src/components/stepThree/StepThreeFormDutchAuction.js
@@ -63,6 +63,9 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
     if (reload) {
       const tiers = values && values.tiers ? values.tiers : []
       tiers.forEach((tier, index) => {
+        form.mutators.setFieldTouched(`tiers[${index}].tier`, true)
+        form.mutators.setFieldTouched(`tiers[${index}].updatable`, true)
+        form.mutators.setFieldTouched(`tiers[${index}].whitelistEnabled`, true)
         form.mutators.setFieldTouched(`tiers[${index}].startTime`, true)
         form.mutators.setFieldTouched(`tiers[${index}].endTime`, true)
         form.mutators.setFieldTouched(`tiers[${index}].minRate`, true)

--- a/src/components/stepThree/StepThreeFormDutchAuction.js
+++ b/src/components/stepThree/StepThreeFormDutchAuction.js
@@ -45,6 +45,12 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
     generalStore.setGasTypeSelected(value)
   }
 
+  const handleBurnExcessChange = (value, input) => {
+    const { generalStore } = props
+    generalStore.setBurnExcess(value)
+    input.onChange(value)
+  }
+
   const handleOnChange = ({ values }) => {
     props.tierStore.updateWalletAddress(values.walletAddress, VALID)
     props.tierStore.updateBurnExcess(values.burnExcess, VALID)
@@ -107,7 +113,7 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
                             type="radio"
                             checked={input.value === 'yes'}
                             value="yes"
-                            onChange={() => input.onChange('yes')}
+                            onChange={e => handleBurnExcessChange(e.target.value, input)}
                           />
                           <span className="title">yes</span>
                         </label>
@@ -116,7 +122,7 @@ export const StepThreeFormDutchAuction = ({ handleSubmit, invalid, submitting, p
                             type="radio"
                             checked={input.value === 'no'}
                             value="no"
-                            onChange={() => input.onChange('no')}
+                            onChange={e => handleBurnExcessChange(e.target.value, input)}
                           />
                           <span className="title">no</span>
                         </label>

--- a/src/components/stepThree/StepThreeFormMintedCapped.js
+++ b/src/components/stepThree/StepThreeFormMintedCapped.js
@@ -65,7 +65,7 @@ export const StepThreeFormMintedCapped = ({
   const handleValidateGasPrice = value => {
     const errors = composeValidators(
       isDecimalPlacesNotGreaterThan(VALIDATION_MESSAGES.DECIMAL_PLACES_9)(9),
-      isGreaterOrEqualThan(VALIDATION_MESSAGES.NUMBER_GREATER_THAN)(0.1)
+      isGreaterOrEqualThan(VALIDATION_MESSAGES.NUMBER_GREATER_OR_EQUAL_THAN)(0.1)
     )(value.price)
     if (errors) return errors.shift()
   }

--- a/src/components/stepThree/StepThreeFormMintedCapped.js
+++ b/src/components/stepThree/StepThreeFormMintedCapped.js
@@ -78,6 +78,7 @@ export const StepThreeFormMintedCapped = ({
         form.mutators.setFieldTouched(`tiers[${index}].updatable`, true)
         form.mutators.setFieldTouched(`tiers[${index}].whitelistEnabled`, true)
         form.mutators.setFieldTouched(`tiers[${index}].startTime`, true)
+        form.mutators.setFieldTouched(`tiers[${index}].rate`, true)
         form.mutators.setFieldTouched(`tiers[${index}].endTime`, true)
         form.mutators.setFieldTouched(`tiers[${index}].minRate`, true)
         form.mutators.setFieldTouched(`tiers[${index}].maxRate`, true)

--- a/src/components/stepThree/StepThreeFormMintedCapped.js
+++ b/src/components/stepThree/StepThreeFormMintedCapped.js
@@ -58,8 +58,8 @@ export const StepThreeFormMintedCapped = ({
    * @param value
    */
   const updateGasTypeSelected = value => {
-    const { generalStore } = props
-    generalStore.setGasTypeSelected(value)
+    const { updateGasTypeSelected } = props
+    updateGasTypeSelected(value)
   }
 
   const handleValidateGasPrice = value => {

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -73,8 +73,13 @@ export class stepThree extends React.Component {
       })
     }
 
-    let initialTiers = []
-    initialTiers.push(tierStore.getTiers(crowdsaleStore))
+    let initialTiers
+
+    if (crowdsaleStore.isDutchAuction) {
+      initialTiers = [JSON.parse(JSON.stringify(tierStore.tiers))[0]]
+    } else {
+      initialTiers = JSON.parse(JSON.stringify(tierStore.tiers))
+    }
 
     return {
       initialTiers: initialTiers,

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -59,7 +59,7 @@ export class stepThree extends React.Component {
   }
 
   async load() {
-    const { tierStore, generalStore, web3Store } = this.props
+    const { tierStore, generalStore, web3Store, crowdsaleStore } = this.props
 
     await sleep(1000)
 
@@ -68,8 +68,11 @@ export class stepThree extends React.Component {
       tierStore.addCrowdsale(web3Store.curAddress)
     }
 
+    let initialTiers = []
+    initialTiers.push(tierStore.getTiers(crowdsaleStore))
+
     return {
-      initialTiers: JSON.parse(JSON.stringify(tierStore.tiers)),
+      initialTiers: initialTiers,
       burnExcess: generalStore.burnExcess
     }
   }

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -35,7 +35,8 @@ export class stepThree extends React.Component {
     loading: false,
     reload: false,
     initialTiers: [],
-    burnExcess: 'no'
+    burnExcess: 'no',
+    gasTypeSelected: {}
   }
 
   async componentDidMount() {
@@ -43,7 +44,7 @@ export class stepThree extends React.Component {
     await checkWeb3(web3Store.web3)
 
     this.setState({ loading: true })
-    const { initialTiers, burnExcess } = await this.load()
+    const { initialTiers, burnExcess, gasTypeSelected } = await this.load()
 
     try {
       await gasPriceStore.updateValues()
@@ -54,7 +55,8 @@ export class stepThree extends React.Component {
     this.setState({
       loading: false,
       initialTiers: initialTiers,
-      burnExcess: burnExcess
+      burnExcess: burnExcess,
+      gasTypeSelected: gasTypeSelected
     })
     window.scrollTo(0, 0)
   }
@@ -83,7 +85,8 @@ export class stepThree extends React.Component {
 
     return {
       initialTiers: initialTiers,
-      burnExcess: generalStore.burnExcess
+      burnExcess: generalStore.burnExcess,
+      gasTypeSelected: generalStore.getGasTypeSelected
     }
   }
 
@@ -176,7 +179,7 @@ export class stepThree extends React.Component {
           decorators={[this.calculator]}
           initialValues={{
             walletAddress: web3Store.curAddress,
-            gasPrice: gasPriceStore.gasPricesInGwei[0],
+            gasPrice: this.state.gasTypeSelected,
             whitelistEnabled: 'no',
             burnExcess: this.state.burnExcess,
             tiers: this.state.initialTiers

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -33,7 +33,8 @@ export class stepThree extends React.Component {
   state = {
     loading: false,
     reload: false,
-    initialTiers: []
+    initialTiers: [],
+    burnExcess: 'no'
   }
 
   async componentDidMount() {
@@ -41,7 +42,7 @@ export class stepThree extends React.Component {
     await checkWeb3(web3Store.web3)
 
     this.setState({ loading: true })
-    const initialTiers = await this.load()
+    const { initialTiers, burnExcess } = await this.load()
 
     try {
       await gasPriceStore.updateValues()
@@ -49,12 +50,16 @@ export class stepThree extends React.Component {
       noGasPriceAvailable()
     }
 
-    this.setState({ loading: false, initialTiers: initialTiers })
+    this.setState({
+      loading: false,
+      initialTiers: initialTiers,
+      burnExcess: burnExcess
+    })
     window.scrollTo(0, 0)
   }
 
   async load() {
-    const { tierStore, web3Store } = this.props
+    const { tierStore, generalStore, web3Store } = this.props
 
     await sleep(1000)
 
@@ -63,7 +68,10 @@ export class stepThree extends React.Component {
       tierStore.addCrowdsale(web3Store.curAddress)
     }
 
-    return JSON.parse(JSON.stringify(tierStore.tiers))
+    return {
+      initialTiers: JSON.parse(JSON.stringify(tierStore.tiers)),
+      burnExcess: generalStore.burnExcess
+    }
   }
 
   goToDeploymentStage = () => {
@@ -157,7 +165,7 @@ export class stepThree extends React.Component {
             walletAddress: web3Store.curAddress,
             gasPrice: gasPriceStore.gasPricesInGwei[0],
             whitelistEnabled: 'no',
-            burnExcess: 'no',
+            burnExcess: this.state.burnExcess,
             tiers: this.state.initialTiers
           }}
           component={stepThreeComponent}

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -156,6 +156,14 @@ export class stepThree extends React.Component {
     }
   })
 
+  updateGasTypeSelected = value => {
+    const { generalStore } = this.props
+    this.setState({
+      gasTypeSelected: value
+    })
+    generalStore.setGasTypeSelected(value)
+  }
+
   render() {
     if (this.state.initialTiers.length === 0) {
       //Not render the form until tiers are setup
@@ -188,6 +196,7 @@ export class stepThree extends React.Component {
           addCrowdsale={tierStore.addCrowdsale}
           gasPricesInGwei={gasPriceStore.gasPricesInGwei}
           decimals={tokenStore.decimals}
+          updateGasTypeSelected={this.updateGasTypeSelected}
           tierStore={tierStore}
           generalStore={generalStore}
           crowdsaleStore={crowdsaleStore}

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -12,6 +12,7 @@ import { getStep3Component } from './utils'
 import createDecorator from 'final-form-calculate'
 import logdown from 'logdown'
 import { sleep } from '../../utils/utils'
+import setFieldTouched from 'final-form-set-field-touched'
 
 const logger = logdown('TW:stepThree')
 
@@ -66,6 +67,10 @@ export class stepThree extends React.Component {
     if (tierStore.tiers.length === 0) {
       logger.log('Web3store', web3Store)
       tierStore.addCrowdsale(web3Store.curAddress)
+    } else {
+      this.setState({
+        reload: true
+      })
     }
 
     let initialTiers = []
@@ -162,7 +167,7 @@ export class stepThree extends React.Component {
         <StepNavigation activeStep={CROWDSALE_SETUP} />
         <Form
           onSubmit={this.handleOnSubmit}
-          mutators={{ ...arrayMutators }}
+          mutators={{ ...arrayMutators, setFieldTouched }}
           decorators={[this.calculator]}
           initialValues={{
             walletAddress: web3Store.curAddress,
@@ -178,6 +183,7 @@ export class stepThree extends React.Component {
           tierStore={tierStore}
           generalStore={generalStore}
           crowdsaleStore={crowdsaleStore}
+          reload={this.state.reload}
         />
         <Loader show={this.state.loading} />
       </section>

--- a/src/components/stepThree/index.js
+++ b/src/components/stepThree/index.js
@@ -158,9 +158,6 @@ export class stepThree extends React.Component {
 
   updateGasTypeSelected = value => {
     const { generalStore } = this.props
-    this.setState({
-      gasTypeSelected: value
-    })
     generalStore.setGasTypeSelected(value)
   }
 

--- a/src/stores/GeneralStore.js
+++ b/src/stores/GeneralStore.js
@@ -44,7 +44,7 @@ class GeneralStore {
   // Getters
   @computed
   get getGasTypeSelected() {
-    return this.gasTypeSelected
+    return this.gasTypeSelected || GAS_PRICE.SLOW
   }
 }
 

--- a/src/stores/GeneralStore.js
+++ b/src/stores/GeneralStore.js
@@ -1,10 +1,11 @@
-import { observable, action } from 'mobx'
+import { observable, action, computed } from 'mobx'
 import { GAS_PRICE } from '../utils/constants'
 import autosave from './autosave'
 
 class GeneralStore {
   @observable networkID
   @observable gasPrice = GAS_PRICE.FAST.PRICE
+  @observable gasTypeSelected
 
   constructor() {
     this.reset()
@@ -22,9 +23,21 @@ class GeneralStore {
   }
 
   @action
+  setGasTypeSelected = gasTypeSeleted => {
+    this.gasTypeSelected = gasTypeSeleted
+  }
+
+  @action
   reset = () => {
     this.networkID = undefined
     this.gasPrice = GAS_PRICE.FAST.PRICE
+    this.gasTypeSelected = GAS_PRICE.SLOW
+  }
+
+  // Getters
+  @computed
+  get getGasTypeSelected() {
+    return this.gasTypeSelected
   }
 }
 

--- a/src/stores/GeneralStore.js
+++ b/src/stores/GeneralStore.js
@@ -6,6 +6,7 @@ class GeneralStore {
   @observable networkID
   @observable gasPrice = GAS_PRICE.FAST.PRICE
   @observable gasTypeSelected
+  @observable burnExcess
 
   constructor() {
     this.reset()
@@ -28,10 +29,16 @@ class GeneralStore {
   }
 
   @action
+  setBurnExcess = burnExcess => {
+    this.burnExcess = burnExcess
+  }
+
+  @action
   reset = () => {
     this.networkID = undefined
     this.gasPrice = GAS_PRICE.FAST.PRICE
     this.gasTypeSelected = GAS_PRICE.SLOW
+    this.burnExcess = 'no'
   }
 
   // Getters

--- a/src/stores/GeneralStore.js
+++ b/src/stores/GeneralStore.js
@@ -1,6 +1,7 @@
 import { observable, action, computed } from 'mobx'
 import { GAS_PRICE } from '../utils/constants'
 import autosave from './autosave'
+import { objectKeysToLowerCase } from '../utils/utils'
 
 class GeneralStore {
   @observable networkID
@@ -37,14 +38,14 @@ class GeneralStore {
   reset = () => {
     this.networkID = undefined
     this.gasPrice = GAS_PRICE.FAST.PRICE
-    this.gasTypeSelected = GAS_PRICE.SLOW
+    this.gasTypeSelected = objectKeysToLowerCase(GAS_PRICE.SLOW)
     this.burnExcess = 'no'
   }
 
   // Getters
   @computed
   get getGasTypeSelected() {
-    return this.gasTypeSelected || GAS_PRICE.SLOW
+    return this.gasTypeSelected || objectKeysToLowerCase(GAS_PRICE.SLOW)
   }
 }
 

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -103,14 +103,32 @@ class TierStore {
 
   @action
   updateWalletAddress = (value, validity) => {
-    this.tiers[0].walletAddress = value
-    this.validTiers[0].walletAddress = validity
+    if (this.tiers.length > 0) {
+      this.tiers[0].walletAddress = value
+    } else {
+      this.tiers.push({ walletAddress: value })
+    }
+
+    if (this.validTiers.length > 0) {
+      this.validTiers[0].walletAddress = validity
+    } else {
+      this.validTiers.push({ walletAddress: validity })
+    }
   }
 
   @action
   updateBurnExcess = (value, validity) => {
-    this.tiers[0].burnExcess = value
-    this.validTiers[0].burnExcess = validity
+    if (this.tiers.length > 0) {
+      this.tiers[0].burnExcess = value
+    } else {
+      this.tiers.push({ burnExcess: value })
+    }
+
+    if (this.validTiers[0].length > 0) {
+      this.validTiers[0].burnExcess = validity
+    } else {
+      this.validTiers.push({ burnExcess: validity })
+    }
   }
 
   @action

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -334,6 +334,14 @@ class TierStore {
   validateWhitelistedAddressLength(tierIndex) {
     return this.tiers[tierIndex].whitelist.length < LIMIT_WHITELISTED_ADDRESSES
   }
+
+  getTiers(crowdsaleStore) {
+    if (crowdsaleStore.isDutchAuction) {
+      return JSON.parse(JSON.stringify(this.tiers))[0]
+    } else {
+      return JSON.parse(JSON.stringify(this.tiers))
+    }
+  }
 }
 
 export default TierStore

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -334,7 +334,6 @@ class TierStore {
   validateWhitelistedAddressLength(tierIndex) {
     return this.tiers[tierIndex].whitelist.length < LIMIT_WHITELISTED_ADDRESSES
   }
-
 }
 
 export default TierStore

--- a/src/stores/TierStore.js
+++ b/src/stores/TierStore.js
@@ -335,13 +335,6 @@ class TierStore {
     return this.tiers[tierIndex].whitelist.length < LIMIT_WHITELISTED_ADDRESSES
   }
 
-  getTiers(crowdsaleStore) {
-    if (crowdsaleStore.isDutchAuction) {
-      return JSON.parse(JSON.stringify(this.tiers))[0]
-    } else {
-      return JSON.parse(JSON.stringify(this.tiers))
-    }
-  }
 }
 
 export default TierStore

--- a/src/stores/Web3Store.js
+++ b/src/stores/Web3Store.js
@@ -1,5 +1,5 @@
 import Web3 from 'web3'
-import { observable } from 'mobx'
+import { observable, action } from 'mobx'
 import { getNetworkID } from '../utils/utils'
 import { CrowdsaleConfig } from '../components/Common/config'
 import { CHAINS, REACT_PREFIX } from '../utils/constants'
@@ -12,18 +12,23 @@ class Web3Store {
   @observable curAddress
   @observable accounts
 
-  constructor(strategies) {
+  constructor() {
     this.getWeb3(web3 => {
       if (web3) {
         this.web3 = web3
         web3.eth.getAccounts().then(accounts => {
           this.accounts = accounts
           if (accounts.length > 0) {
-            this.curAddress = accounts[0]
+            this.setProperty('curAddress', accounts[0])
           }
         })
       }
     })
+  }
+
+  @action
+  setProperty = (property, value) => {
+    this[property] = value
   }
 
   getInfuraLink = network => {
@@ -72,7 +77,7 @@ class Web3Store {
     } else {
       // window.web3 == web3 most of the time. Don't override the provided,
       // web3, just wrap it in your Web3.
-      var myWeb3 = new Web3(web3.currentProvider)
+      let myWeb3 = new Web3(web3.currentProvider)
 
       cb(myWeb3, false)
       return myWeb3

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -147,7 +147,8 @@ export const VALIDATION_MESSAGES = {
   DATE_IS_SAME_OR_PREVIOUS: 'Should be same or previous than specified time',
   PATTERN: 'Should match the specified pattern',
   DECIMAL_PLACES_9: 'Should not have more than 9 decimals',
-  NUMBER_GREATER_THAN: 'Should be greater than 0.1'
+  NUMBER_GREATER_THAN: 'Should be greater than 0.1',
+  NUMBER_GREATER_OR_EQUAL_THAN: 'Should be greater or equal than 0.1'
 }
 
 //descriptions of input fields

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -87,7 +87,7 @@ export const GAS_PRICE = {
   },
   CUSTOM: {
     ID: 'custom',
-    PRICE: 0,
+    PRICE: 0.1,
     DESCRIPTION: 'Custom'
   },
   API: {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -178,3 +178,18 @@ export const toBigNumber = (value, force = true) => {
 export const sleep = async ms => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
+
+export const objectKeysToLowerCase = input => {
+  if (typeof input !== 'object') {
+    return input
+  }
+  if (Array.isArray(input)) {
+    return input.map(objectKeysToLowerCase)
+  }
+  return Object.keys(input).reduce((newObj, key) => {
+    let val = input[key]
+    let newVal = typeof val === 'object' ? objectKeysToLowerCase(val) : val
+    newObj[key.toLowerCase()] = newVal
+    return newObj
+  }, {})
+}

--- a/test/components/manage/__snapshots__/ManageForm.spec.js.snap
+++ b/test/components/manage/__snapshots__/ManageForm.spec.js.snap
@@ -19,6 +19,11 @@ exports[`ManageForm should render for Dutch Auction 1`] = `
   generalStore={
     GeneralStore {
       "gasPrice": 15000000000,
+      "gasTypeSelected": Object {
+        "DESCRIPTION": "Safe and Cheap",
+        "ID": "slow",
+        "PRICE": 5000000000,
+      },
       "networkID": undefined,
     }
   }
@@ -255,6 +260,11 @@ exports[`ManageForm should render for Dutch Auction 1`] = `
             generalStore={
               GeneralStore {
                 "gasPrice": 15000000000,
+                "gasTypeSelected": Object {
+                  "DESCRIPTION": "Safe and Cheap",
+                  "ID": "slow",
+                  "PRICE": 5000000000,
+                },
                 "networkID": undefined,
               }
             }
@@ -336,6 +346,11 @@ exports[`ManageForm should render the component with tiers 1`] = `
   generalStore={
     GeneralStore {
       "gasPrice": 15000000000,
+      "gasTypeSelected": Object {
+        "DESCRIPTION": "Safe and Cheap",
+        "ID": "slow",
+        "PRICE": 5000000000,
+      },
       "networkID": undefined,
     }
   }
@@ -1093,6 +1108,11 @@ exports[`ManageForm should render the component with tiers 1`] = `
             generalStore={
               GeneralStore {
                 "gasPrice": 15000000000,
+                "gasTypeSelected": Object {
+                  "DESCRIPTION": "Safe and Cheap",
+                  "ID": "slow",
+                  "PRICE": 5000000000,
+                },
                 "networkID": undefined,
               }
             }
@@ -4402,6 +4422,11 @@ exports[`ManageForm should render the component without tiers 1`] = `
   generalStore={
     GeneralStore {
       "gasPrice": 15000000000,
+      "gasTypeSelected": Object {
+        "DESCRIPTION": "Safe and Cheap",
+        "ID": "slow",
+        "PRICE": 5000000000,
+      },
       "networkID": undefined,
     }
   }
@@ -4638,6 +4663,11 @@ exports[`ManageForm should render the component without tiers 1`] = `
             generalStore={
               GeneralStore {
                 "gasPrice": 15000000000,
+                "gasTypeSelected": Object {
+                  "DESCRIPTION": "Safe and Cheap",
+                  "ID": "slow",
+                  "PRICE": 5000000000,
+                },
                 "networkID": undefined,
               }
             }

--- a/test/components/manage/__snapshots__/ManageForm.spec.js.snap
+++ b/test/components/manage/__snapshots__/ManageForm.spec.js.snap
@@ -21,9 +21,9 @@ exports[`ManageForm should render for Dutch Auction 1`] = `
       "burnExcess": "no",
       "gasPrice": 15000000000,
       "gasTypeSelected": Object {
-        "DESCRIPTION": "Safe and Cheap",
-        "ID": "slow",
-        "PRICE": 5000000000,
+        "description": "Safe and Cheap",
+        "id": "slow",
+        "price": 5000000000,
       },
       "networkID": undefined,
     }
@@ -263,9 +263,9 @@ exports[`ManageForm should render for Dutch Auction 1`] = `
                 "burnExcess": "no",
                 "gasPrice": 15000000000,
                 "gasTypeSelected": Object {
-                  "DESCRIPTION": "Safe and Cheap",
-                  "ID": "slow",
-                  "PRICE": 5000000000,
+                  "description": "Safe and Cheap",
+                  "id": "slow",
+                  "price": 5000000000,
                 },
                 "networkID": undefined,
               }
@@ -350,9 +350,9 @@ exports[`ManageForm should render the component with tiers 1`] = `
       "burnExcess": "no",
       "gasPrice": 15000000000,
       "gasTypeSelected": Object {
-        "DESCRIPTION": "Safe and Cheap",
-        "ID": "slow",
-        "PRICE": 5000000000,
+        "description": "Safe and Cheap",
+        "id": "slow",
+        "price": 5000000000,
       },
       "networkID": undefined,
     }
@@ -1113,9 +1113,9 @@ exports[`ManageForm should render the component with tiers 1`] = `
                 "burnExcess": "no",
                 "gasPrice": 15000000000,
                 "gasTypeSelected": Object {
-                  "DESCRIPTION": "Safe and Cheap",
-                  "ID": "slow",
-                  "PRICE": 5000000000,
+                  "description": "Safe and Cheap",
+                  "id": "slow",
+                  "price": 5000000000,
                 },
                 "networkID": undefined,
               }
@@ -4428,9 +4428,9 @@ exports[`ManageForm should render the component without tiers 1`] = `
       "burnExcess": "no",
       "gasPrice": 15000000000,
       "gasTypeSelected": Object {
-        "DESCRIPTION": "Safe and Cheap",
-        "ID": "slow",
-        "PRICE": 5000000000,
+        "description": "Safe and Cheap",
+        "id": "slow",
+        "price": 5000000000,
       },
       "networkID": undefined,
     }
@@ -4670,9 +4670,9 @@ exports[`ManageForm should render the component without tiers 1`] = `
                 "burnExcess": "no",
                 "gasPrice": 15000000000,
                 "gasTypeSelected": Object {
-                  "DESCRIPTION": "Safe and Cheap",
-                  "ID": "slow",
-                  "PRICE": 5000000000,
+                  "description": "Safe and Cheap",
+                  "id": "slow",
+                  "price": 5000000000,
                 },
                 "networkID": undefined,
               }

--- a/test/components/manage/__snapshots__/ManageForm.spec.js.snap
+++ b/test/components/manage/__snapshots__/ManageForm.spec.js.snap
@@ -18,6 +18,7 @@ exports[`ManageForm should render for Dutch Auction 1`] = `
   }
   generalStore={
     GeneralStore {
+      "burnExcess": "no",
       "gasPrice": 15000000000,
       "gasTypeSelected": Object {
         "DESCRIPTION": "Safe and Cheap",
@@ -259,6 +260,7 @@ exports[`ManageForm should render for Dutch Auction 1`] = `
             }
             generalStore={
               GeneralStore {
+                "burnExcess": "no",
                 "gasPrice": 15000000000,
                 "gasTypeSelected": Object {
                   "DESCRIPTION": "Safe and Cheap",
@@ -345,6 +347,7 @@ exports[`ManageForm should render the component with tiers 1`] = `
   }
   generalStore={
     GeneralStore {
+      "burnExcess": "no",
       "gasPrice": 15000000000,
       "gasTypeSelected": Object {
         "DESCRIPTION": "Safe and Cheap",
@@ -1107,6 +1110,7 @@ exports[`ManageForm should render the component with tiers 1`] = `
             }
             generalStore={
               GeneralStore {
+                "burnExcess": "no",
                 "gasPrice": 15000000000,
                 "gasTypeSelected": Object {
                   "DESCRIPTION": "Safe and Cheap",
@@ -4421,6 +4425,7 @@ exports[`ManageForm should render the component without tiers 1`] = `
   }
   generalStore={
     GeneralStore {
+      "burnExcess": "no",
       "gasPrice": 15000000000,
       "gasTypeSelected": Object {
         "DESCRIPTION": "Safe and Cheap",
@@ -4662,6 +4667,7 @@ exports[`ManageForm should render the component without tiers 1`] = `
             }
             generalStore={
               GeneralStore {
+                "burnExcess": "no",
                 "gasPrice": 15000000000,
                 "gasTypeSelected": Object {
                   "DESCRIPTION": "Safe and Cheap",

--- a/test/components/stepTwo/__snapshots__/StepTwoForm.spec.js.snap
+++ b/test/components/stepTwo/__snapshots__/StepTwoForm.spec.js.snap
@@ -183,6 +183,7 @@ exports[`StepTwoForm should render StepTwoForm for Dutch Auction Crowdsale 1`] =
     <button
       className="button button_fill button_no_border button_disabled"
       disabled={true}
+      onClick={undefined}
       type="submit"
     >
       Continue
@@ -502,6 +503,7 @@ exports[`StepTwoForm should render StepTwoForm for Minted Capped Crowdsale 1`] =
     <button
       className="button button_fill button_no_border"
       disabled={false}
+      onClick={undefined}
       type="submit"
     >
       Continue


### PR DESCRIPTION
This is an integration PR for the step 3.

How to test it and what to test:
- Go to the home
- Create a crowdsale
- In the first step, press button "New crowdsale"
- Select the type of strategy
- Go to the second step
- Go back to step 1
- Should keep the selected strategy
- Refresh the step 1 page
- Should keep the selected strategy
- Got to the second step
- Complete the form
- Refresh the page, should keep the data
- Add reserved tokens
- Refresh the page, should keep the data
- Got to the third step
- Complete the form
- Refresh the page, should keep the data
- Go to the home, and press button "New crowdsale"
- The selected strategy must be the default, "WHITELIST WITH CAP"
- Go to the second step
- The form must be empty
