### PR TITLE
(Feature) Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Default values
+### $author  // the project owner in github
+### $project // the name of the project in github
+### $branch  // the branch to checkout
+ARG author=poanetwork
+ARG project=token-wizard
+ARG branch=master
+
+# Docker setup
+FROM travisci/ci-garnet:packer-1512502276-986baf0
+RUN chmod go-w /usr/local/clang-5.0.0/bin
+USER travis
+WORKDIR /home/travis/builds
+RUN git clone https://github.com/travis-ci/travis-build.git
+WORKDIR travis-build
+RUN mkdir -p /home/travis/.travis
+RUN bash -lc "gem install travis"
+RUN bash -lc "travis"
+RUN ln -s $(pwd) /home/travis/.travis/travis-build
+RUN bash -lc "bundle install"
+WORKDIR /home/travis/builds
+RUN git clone https://github.com/travis-ci/travis-support.git
+WORKDIR travis-support
+RUN bash -lc "gem build travis-support.gemspec"
+RUN bash -lc "gem install travis-support"
+WORKDIR /home/travis/builds
+RUN git clone https://github.com/travis-ci/travis-rollout.git
+WORKDIR travis-rollout
+RUN bash -lc "gem build travis-rollout.gemspec"
+RUN bash -lc "gem install travis-rollout"
+WORKDIR /home/travis/builds
+RUN git clone https://github.com/travis-ci/travis-github_apps.git
+WORKDIR travis-github_apps
+RUN bash -lc "gem build travis-github_apps.gemspec"
+RUN bash -lc "gem install travis-github_apps"
+
+# Repo-related tasks
+ARG author
+ARG project
+ARG branch
+RUN mkdir -p /home/travis/builds/$author
+WORKDIR /home/travis/builds/$author
+RUN git clone -b $branch https://github.com/$author/$project.git
+WORKDIR $project
+CMD ["bash"]


### PR DESCRIPTION
Included `Dockerfile` contains `travis`, which may be helpful for running local test in a container before creating the PR.

Steps to use it:

1. install docker [https://docs.docker.com/install/#supported-platforms](https://docs.docker.com/install/#supported-platforms)
1. move to the project root
1. `docker build -t tw .` (where `tw` is the name of the docker image created and `.` is the location of the Dockerfile)
1. `docker run -ti tw`
1. once the image has started, run `travis compile > ci.sh`
1. edit `ci.sh` file and set the corresponding branch (search for `branch` word and replace: `branch\=\'\'` with `branch\=\'master\'`)
1. `bash ci.sh`

---
Docker build can receive three arguments `author`, `project`, `branch`.
Default values:
 - `author`: `poanetwork`
 - `project`: `token-wizard`
 - `branch`: `master`

So you can build a docker image pointing to a specific author/project/branch.
i.e.: `docker build -t tw . --build-arg branch=2.0` will create the image pointing to branch `2.0`

---
**Important:** Before running `bash ci.sh` you have to always find/replace the `branch` that the `ci.sh` is pointing to.
