### PR TITLE
(Fix) Remove proxies registry binary code from the storage

### DIFF
--- a/src/stores/utils.js
+++ b/src/stores/utils.js
@@ -56,7 +56,7 @@ async function getCrowdsaleAsset(contractName, stateProp, networkID) {
       ? setFlatFileContentToState(`./contracts/${stateProp}.sol`)
       : Promise.resolve()
   const whenBin =
-    stateProp === 'MintedCappedProxy' || stateProp === 'DutchProxy' || stateProp === 'ProxiesRegistry'
+    stateProp === 'MintedCappedProxy' || stateProp === 'DutchProxy'
       ? setFlatFileContentToState(`./contracts/${stateProp}.bin`)
       : Promise.resolve()
   let abi


### PR DESCRIPTION
Remove proxies registry binary code from the storage because proxies registry has been deployed before Token wizard deployment.