### PR TITLE
Fix error in step4 in netlify

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -45,7 +45,9 @@ measureFileSizesBeforeBuild(paths.appBuild)
   .then(previousFileSizes => {
     // Remove all content but keep the directory so that
     // if you're in it, you don't end up in Trash
-    fs.emptyDirSync(paths.appBuild);
+
+    deleteFolderRecursive(paths.appBuild);
+
     // Merge with the public folder
     copyPublicFolder();
     // Start the webpack build
@@ -141,4 +143,31 @@ function copyPublicFolder() {
     dereference: true,
     filter: file => file !== paths.appHtml,
   });
+}
+
+function deleteFolderRecursive(pathApp) {
+  const pathBuild = path.join(__dirname, `../build`)
+  const pathContract = path.join(__dirname, `../build/contracts`)
+  const pathMetadata = path.join(__dirname, `../build/metadata`)
+
+  if (pathApp === pathContract || pathApp === pathMetadata) {
+    console.log(`Path excluded to delete: ${pathApp}`)
+    return
+  } else {
+    if (fs.existsSync(pathApp)) {
+      fs.readdirSync(pathApp).forEach(function(file) {
+        let curPath = `${pathApp}/${file}`
+        if (fs.lstatSync(curPath).isDirectory()) {
+          // recurse
+          deleteFolderRecursive(curPath)
+        } else {
+          // delete file
+          fs.unlinkSync(curPath)
+        }
+      })
+      if (pathApp !== pathBuild) {
+        fs.rmdirSync(pathApp)
+      }
+    }
+  }
 }

--- a/scripts/moveSolcVersionOutput.js
+++ b/scripts/moveSolcVersionOutput.js
@@ -2,6 +2,7 @@
  * Script that create a json file with the truffle version in a public folder
  */
 
+const path = require('path')
 const shell = require('shelljs')
 const { writeFile } = require('./helpers/utils')
 
@@ -30,11 +31,14 @@ const createObjectVersion = (strategy, content) => {
     if (!strategiesAllowed.includes(strategy)) {
       throw new Error('Strategy doesnt exist')
     }
-    const destinyPath = `${__dirname}/../${directory}/metadata/${strategy}TruffleVersions.json`
+
+    const destinyPath = path.join(__dirname, `../${directory}/metadata/${strategy}TruffleVersions.json`)
 
     writeFile(destinyPath, content, err => {
       if (err) {
         console.log(`Error creating version file`, err)
+      } else {
+        console.log(`Move ${destinyPath} this content ${JSON.stringify(content)}`)
       }
     })
   } catch (e) {

--- a/scripts/moveTruffleConfig.js
+++ b/scripts/moveTruffleConfig.js
@@ -2,6 +2,7 @@
  * Script that move truffle config to a public folder
  */
 
+const path = require('path')
 const { copyFile } = require('./helpers/utils')
 
 const directory = process.argv.slice(2)[0] || 'public'
@@ -12,12 +13,17 @@ const copyStrategy = strategy => {
     if (!strategiesAllowed.includes(strategy)) {
       throw new Error('Strategy doesnt exist')
     }
-    const originPath = `${__dirname}/../submodules/auth-os-applications/TokenWizard/crowdsale/${strategy}Crowdsale/truffle.js`
-    const destinyPath = `${__dirname}/../${directory}/metadata/${strategy}CrowdsaleTruffle.js`
+    const originPath = path.join(
+      __dirname,
+      `../submodules/auth-os-applications/TokenWizard/crowdsale/${strategy}Crowdsale/truffle.js`
+    )
+    const destinyPath = path.join(__dirname, `../${directory}/metadata/${strategy}CrowdsaleTruffle.js`)
 
     copyFile(originPath, destinyPath, err => {
       if (err) {
         console.log(`Error moving files`, err)
+      } else {
+        console.log(`Move ${originPath} - Destiny ${destinyPath}`)
       }
     })
   } catch (e) {


### PR DESCRIPTION
Steps to build:
- $ git clone git@github.com:poanetwork/token-wizard.git token-wizard-build
- $ cd token-wizard-build
- $ git checkout fix-error-folders-in-build 
- $ cp .env.example .env
- $ npm i (necessary for nps)
- $ npm run build
- $ serve -s build

The problem is because the build script clears the directory
![screenshot_20181023_161715](https://user-images.githubusercontent.com/1144028/47397363-4e1afd00-d705-11e8-8b02-f17287974a2c.png)
![screenshot_20181023_153543](https://user-images.githubusercontent.com/1144028/47397370-52471a80-d705-11e8-9f61-3ec870036e1a.png)
![screenshot_20181023_153522](https://user-images.githubusercontent.com/1144028/47397373-54a97480-d705-11e8-87cd-269ce29ba0f9.png)
